### PR TITLE
fix(eslint-config): use process.cwd() for .gitignore path to fix pnpm CAS compat

### DIFF
--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -1,20 +1,13 @@
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { includeIgnoreFile } from "@eslint/compat";
 import pluginJs from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
-// Get the current file path and directory (node_modules/foo/)
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-// Navigate to the root directory (two levels up from node_modules/foo/)
-const rootDir = path.resolve(__dirname, "../../../");
-
-// Resolve the .gitignore file from the root directory
-const gitignorePath = path.resolve(rootDir, ".gitignore");
+// process.cwd() is always the project root regardless of where the package is
+// installed — ../../../ from import.meta.url breaks in pnpm's CAS deep paths.
+const gitignorePath = path.resolve(process.cwd(), ".gitignore");
 
 /**
  * @see https://eslint.org/docs/latest/use/configure/


### PR DESCRIPTION
## Summary

- `@theholocron/eslint-config` resolved `.gitignore` by navigating `../../../` from `import.meta.url`
- Works in npm (flat `node_modules/@theholocron/eslint-config/`) — 3 levels up lands at project root
- Breaks in pnpm CAS (`node_modules/.pnpm/<pkg>@<ver>_<hash>/node_modules/@theholocron/eslint-config/`) — 3 levels up lands inside the pnpm store, not the project root
- Fix: use `process.cwd()` which always resolves to the actual project root regardless of install layout

## Test plan

- [ ] Run `pnpm install` in a repo that uses \`@theholocron/eslint-config\` via pnpm, verify eslint no longer throws \`ENOENT\` on the \`.gitignore\` path
- [ ] Confirm \`.gitignore\` is still respected in ESLint (ignored files not linted)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->