### PR TITLE
fix(dco): add Signed-off-by to automated commit messages

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -45,7 +45,7 @@
       "@semantic-release/git",
       {
         "assets": ["CHANGELOG.md", "package.json", "packages/*/package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}\n\nSigned-off-by: Newton <5769156+iamnewton@users.noreply.github.com>"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
## Summary

- Adds `Signed-off-by: Newton <5769156+iamnewton@users.noreply.github.com>` to the `@semantic-release/git` commit message in `.releaserc.json`
- Unblocks the release workflow which has been failing DCO on every push to `main`

The broader fix (git identity + `format.signoff=true` in the release/sync workflow templates) is landing via the `theholocron/.github` sync PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->