### PR TITLE
fix(eslint-config): disable n/hashbang in library bundle

### DIFF
--- a/packages/eslint-config/bundles/library.js
+++ b/packages/eslint-config/bundles/library.js
@@ -7,5 +7,15 @@ export function library() {
 		...base(),
 		...node(),
 		...typescript(),
+		{
+			name: "@theholocron/library",
+			rules: {
+				// Library packages often include dev scripts with shebangs that aren't
+				// bin entries, and CLI entry shebangs are commonly injected by bundlers
+				// (e.g. tsdown banner) rather than written in source. The hashbang rule
+				// produces false positives in both cases for the library use-case.
+				"n/hashbang": "off",
+			},
+		},
 	];
 }


### PR DESCRIPTION
## Summary

- Adds `n/hashbang: "off"` to the `library()` bundle override block in `bundles/library.js`

## Why

Library packages have two common cases where `n/hashbang` produces false positives:

1. **Dev scripts** — `scripts/validate.mjs` and similar files have shebangs so they can be run directly, but they're not registered as `bin` entries. The rule flags them as "needs no shebang."
2. **Bundler-injected shebangs** — CLI entry points (e.g. `src/cli.ts`) intentionally omit a shebang in source because the bundler (tsdown `banner.js`) injects it at build time. The rule flags the source file as "needs shebang."

Both are false positives for the library use-case. `n/hashbang` remains on in `node-app` and `next-app` bundles where it's genuinely useful.

## Test plan

- [ ] `pnpm lint` passes in this repo
- [ ] Consume the updated config in `theholocron/holocron` — the `n/hashbang` workspace-level override can be removed once this ships and the catalog is bumped
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->