### PR TITLE
fix(prettier-config): expand tsconfig references arrays with printWidth 80

### DIFF
--- a/packages/prettier-config/prettier.config.js
+++ b/packages/prettier-config/prettier.config.js
@@ -23,6 +23,17 @@ const config = {
 				useTabs: false,
 			},
 		},
+		{
+			// printWidth: 80 keeps tsconfig references arrays expanded one-per-line
+			// (the collapsed form fits within 120 chars and becomes hard to scan).
+			// String values never split regardless of printWidth, so this only
+			// affects arrays of objects that exceed 80 chars — in practice just
+			// the references array.
+			files: ["tsconfig*.json"],
+			options: {
+				printWidth: 80,
+			},
+		},
 	],
 };
 


### PR DESCRIPTION
## Summary

- Adds a `tsconfig*.json` override in `prettier.config.js` with `printWidth: 80`

## Why

At the global `printWidth: 120`, a tsconfig `references` array collapses to a single line:

```json
{ "files": [], "references": [{ "path": "./packages/cli" }, { "path": "./packages/cli-utils" }] }
```

That's hard to scan when a project has many package references. At `printWidth: 80`, each entry gets its own line:

```json
{
  "files": [],
  "references": [
    { "path": "./packages/cli" },
    { "path": "./packages/cli-utils" }
  ]
}
```

`printWidth: 80` was chosen over a smaller value (40, 60) because:
- All three produce the same output for `references` arrays — the only thing that matters is being below the ~85-char collapsed line length
- String values never split regardless of `printWidth`, so only arrays of objects that exceed 80 chars are affected
- 80 is a well-understood width that won't make ordinary tsconfig properties expand unexpectedly

## Test plan

- [ ] `pnpm lint` passes in this repo
- [ ] After bumping to this version in a consumer: run `prettier --write` on `tsconfig.json` and confirm references expand one-per-line
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->