### PR TITLE
fix(commitlint-config): pin peer deps to @commitlint@^19; correct README install docs

### DIFF
--- a/.alexrc.json
+++ b/.alexrc.json
@@ -1,3 +1,3 @@
 {
-  "allow": ["dead", "hook", "husky", "period"]
+  "allow": ["dead", "hook", "hooks", "husky", "period"]
 }

--- a/packages/commitlint-config/README.md
+++ b/packages/commitlint-config/README.md
@@ -5,8 +5,10 @@ A [CommitLint configuration](https://commitlint.js.org/reference/configuration.h
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/commitlint-config @commitlint/cli @commitlint/config-conventional
+pnpm add -D @theholocron/commitlint-config @commitlint/cli
 ```
+
+Peer dependencies (`@commitlint/cli ^19`, `@commitlint/config-conventional ^19`) are resolved automatically.
 
 ## Usage
 

--- a/packages/commitlint-config/README.md
+++ b/packages/commitlint-config/README.md
@@ -8,7 +8,7 @@ A [CommitLint configuration](https://commitlint.js.org/reference/configuration.h
 pnpm add -D @theholocron/commitlint-config @commitlint/cli
 ```
 
-Peer dependencies (`@commitlint/cli ^19`, `@commitlint/config-conventional ^19`) are resolved automatically.
+`@commitlint/cli` is required to run commitlint directly (e.g., in git hooks or CI). `@commitlint/config-conventional` is a peer dependency resolved automatically by your package manager.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

The peer dependency fix from #220 landed on `main` but the squash-merge used a `docs:` prefix so semantic-release didn't cut a new version. The broken `conventional-changelog-conventionalcommits@10.x` peer dep is therefore still what npm users get when they install `@theholocron/commitlint-config@6.0.0`.

This `fix:` commit triggers a `6.0.1` patch release with the peer deps already on `main` (`@commitlint@^19`, which uses `conventional-changelog-conventionalcommits@7.x` with a working CJS export).

Also corrects the README install command (`npm` → `pnpm`, removes redundant `@commitlint/config-conventional` which is a peer dep auto-resolved by the package manager).

## Test plan

- [ ] CI passes
- [ ] semantic-release publishes `@theholocron/commitlint-config@6.0.1`
- [ ] After publish: update catalogs in `theholocron/holocron` and `theholocron/clients`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->