### PR TITLE
chore: install holocron CLI and run setup

### DIFF
--- a/.alexrc.json
+++ b/.alexrc.json
@@ -1,3 +1,11 @@
 {
-  "allow": ["dead", "hook", "hooks", "husky", "period"]
+  "allow": [
+    "dead",
+    "failure",
+    "failures",
+    "hook",
+    "hooks",
+    "husky",
+    "period"
+  ]
 }

--- a/.claude/skills/configs-package.md
+++ b/.claude/skills/configs-package.md
@@ -1,3 +1,4 @@
+<!-- editorconfig-checker-disable-file -->
 # configs-package
 
 Scaffold a new shareable config package in `theholocron/configs`.

--- a/.claude/skills/configs-package.md
+++ b/.claude/skills/configs-package.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # configs-package
 
 Scaffold a new shareable config package in `theholocron/configs`.
@@ -41,34 +42,34 @@ Key fields:
 
 ```json
 {
-  "name": "@theholocron/<tool>-config",
-  "version": "4.1.0",
-  "description": "A <Tool> configuration for <purpose>.",
-  "homepage": "https://github.com/theholocron/configs/tree/main/packages/<tool>-config#readme",
-  "bugs": "https://github.com/theholocron/configs/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/theholocron/configs.git"
-  },
-  "license": "GPL-3.0",
-  "author": "Newton Koumantzelis",
-  "type": "module",
-  "exports": {
-    ".": { "import": "./index.js", "default": "./index.js" }
-  },
-  "files": ["index.js"],
-  "peerDependencies": {
-    "<tool>": "^<major>"
-  },
-  "publishConfig": { "access": "public" }
+	"name": "@theholocron/<tool>-config",
+	"version": "4.1.0",
+	"description": "A <Tool> configuration for <purpose>.",
+	"homepage": "https://github.com/theholocron/configs/tree/main/packages/<tool>-config#readme",
+	"bugs": "https://github.com/theholocron/configs/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/theholocron/configs.git"
+	},
+	"license": "GPL-3.0",
+	"author": "Newton Koumantzelis",
+	"type": "module",
+	"exports": {
+		".": { "import": "./index.js", "default": "./index.js" }
+	},
+	"files": ["index.js"],
+	"peerDependencies": {
+		"<tool>": "^<major>"
+	},
+	"publishConfig": { "access": "public" }
 }
 ```
 
 - Match `version` to the current monorepo version (check the root `package.json`).
 - All peer deps that are optional per-preset go under `peerDependenciesMeta`:
-  ```json
-  "peerDependenciesMeta": { "<tool>": { "optional": true } }
-  ```
+    ```json
+    "peerDependenciesMeta": { "<tool>": { "optional": true } }
+    ```
 - Export each preset/bundle as a subpath (`"./presets/node"`, `"./bundles/library"`, …)
   and add those to `"files"`.
 
@@ -80,7 +81,7 @@ Key fields:
  * @type {import("<tool>").Config}
  */
 const config = {
-  // ...
+	// ...
 };
 
 export default config;
@@ -100,7 +101,7 @@ Follow this structure (see existing READMEs for tone):
 ```markdown
 # <Tool> Config
 
-A [<Tool> configuration](<official-docs-url>) for <one-line description>.
+A [<Tool> configuration](official-docs-url) for <one-line description>.
 
 ## Installation
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
-[*.{json,yml}]
+[*.{json,yml,yaml}]
 indent_style = space
 indent_size = 2
 

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,12 +1,12 @@
 {
-  "Version": "v3.0.3",
+  "Version": "v3.7.0",
   "Verbose": false,
   "Format": "",
   "Debug": false,
   "IgnoreDefaults": false,
-  "SpacesAftertabs": false,
+  "SpacesAfterTabs": false,
   "NoColor": false,
-  "Exclude": ["^LICENSE$", "^public/.*"],
+  "Exclude": ["(^|.+/)LICENSE$", "^public/.*"],
   "AllowedContentTypes": [],
   "PassedFiles": [],
   "Disable": {

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,31 +1,20 @@
----
-# Conventional Commits title matching for github/issue-labeler.
-# include-title: 1 is set in the bookkeeping-pr workflow.
-# Patterns use [!:(] to match all valid CC forms:
-#   fix:          normal fix
-#   fix(scope):   scoped fix
-#   fix!:         breaking fix
-#   fix!(scope):  breaking scoped fix
-chore:
-  - "^chore[!:(]"
-
-ci:
-  - "^ci[!:(]"
-
-documentation:
-  - "^docs[!:(]"
+# AUTO-GENERATED — do not edit directly.
+# Source:  theholocron/holocron · packages/cli/src/commands/setup.ts
+# Synced:  2026-07-14T05:02:27.113Z
+# Tool:    holocron setup
+# Changes: run `holocron setup` to regenerate.
 
 bug:
-  - "^fix[!:(]"
+  - '^fix'
+
+dependencies:
+  - '^chore\(deps'
+
+documentation:
+  - '^docs'
 
 enhancement:
-  - "^feat[!:(]"
+  - '^feat'
 
-refactor:
-  - "^refactor[!:(]"
-
-performance:
-  - "^perf[!:(]"
-
-test:
-  - "^test[!:(]"
+github_actions:
+  - '^ci'

--- a/.github/workflows/bookkeeping-pr.yml
+++ b/.github/workflows/bookkeeping-pr.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-10T04:03:36.800Z
+# Synced:  2026-07-14T05:02:27.112Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: PR Bookkeeping

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,20 +1,26 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T05:02:27.109Z
+# Synced:  2026-07-14T05:02:27.107Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
-name: Stale
+name: CodeQL
 
 on: # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   schedule:
-    - cron: "30 1 * * *"
+    - cron: "0 0 * * 1"
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  actions: read
+  contents: read
+  security-events: write
 
 jobs:
-  stale:
-    uses: theholocron/.github/.github/workflows/stale.yml@main
+  codeql:
+    uses: theholocron/.github/.github/workflows/codeql.yml@main
     secrets: inherit

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-10T04:03:36.800Z
+# Synced:  2026-07-14T05:02:27.111Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Dependencies

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-10T04:03:36.800Z
+# Synced:  2026-07-14T05:02:27.110Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Greetings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-10T04:03:36.798Z
+# Synced:  2026-07-14T05:02:27.104Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-10T04:03:36.799Z
+# Synced:  2026-07-14T05:02:27.109Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Release

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-10T04:03:36.799Z
+# Synced:  2026-07-14T05:02:27.108Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Review

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 @../github-private/CLAUDE.md
 
 # CLAUDE.md
@@ -43,10 +44,10 @@ Use the `.claude/skills/configs-package.md` skill, which scaffolds the full
 package. Quick checklist:
 
 1. Create `packages/<tool>-config/` with:
-   - `package.json` — follow the shape of an existing package; include all
-     relevant `peerDependencies` as optional where the tool itself is optional
-   - `index.js` — default export or named export(s) of the config object
-   - `README.md` — Installation + Usage sections; see existing packages for tone
+    - `package.json` — follow the shape of an existing package; include all
+      relevant `peerDependencies` as optional where the tool itself is optional
+    - `index.js` — default export or named export(s) of the config object
+    - `README.md` — Installation + Usage sections; see existing packages for tone
 2. Add the package to `pnpm-workspace.yaml` if it is not auto-discovered.
 3. Verify `pnpm install` resolves and `pnpm lint` passes (ESLint config lints itself).
 4. Open a PR with a `feat:` commit — semantic-release will compute a minor bump

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,4 @@
+<!-- editorconfig-checker-disable-file -->
 @../github-private/CLAUDE.md
 
 # CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@ Shareable configuration used accross the Galaxy.
 
 ## Packages
 
-| Package | Version | Description |
-|---------|---------|-------------|
-| [`@theholocron/browserslist-config`](./packages/browserslist-config) | [![npm](https://img.shields.io/npm/v/@theholocron/browserslist-config)](https://www.npmjs.com/package/@theholocron/browserslist-config) | Browser and device targets |
-| [`@theholocron/bundlewatch-config`](./packages/bundlewatch-config) | [![npm](https://img.shields.io/npm/v/@theholocron/bundlewatch-config)](https://www.npmjs.com/package/@theholocron/bundlewatch-config) | Bundle size monitoring |
-| [`@theholocron/commitlint-config`](./packages/commitlint-config) | [![npm](https://img.shields.io/npm/v/@theholocron/commitlint-config)](https://www.npmjs.com/package/@theholocron/commitlint-config) | Conventional commit enforcement |
-| [`@theholocron/eslint-config`](./packages/eslint-config) | [![npm](https://img.shields.io/npm/v/@theholocron/eslint-config)](https://www.npmjs.com/package/@theholocron/eslint-config) | ESLint rules for JS/TS/React/Next/Node |
-| [`@theholocron/lint-staged-config`](./packages/lint-staged-config) | [![npm](https://img.shields.io/npm/v/@theholocron/lint-staged-config)](https://www.npmjs.com/package/@theholocron/lint-staged-config) | Pre-commit lint-staged hooks |
-| [`@theholocron/prettier-config`](./packages/prettier-config) | [![npm](https://img.shields.io/npm/v/@theholocron/prettier-config)](https://www.npmjs.com/package/@theholocron/prettier-config) | Prettier formatting rules |
-| [`@theholocron/storybook-config`](./packages/storybook-config) | [![npm](https://img.shields.io/npm/v/@theholocron/storybook-config)](https://www.npmjs.com/package/@theholocron/storybook-config) | Storybook addon and theme setup |
-| [`@theholocron/stylelint-config`](./packages/stylelint-config) | [![npm](https://img.shields.io/npm/v/@theholocron/stylelint-config)](https://www.npmjs.com/package/@theholocron/stylelint-config) | StyleLint rules for CSS/SCSS |
-| [`@theholocron/tsconfig`](./packages/tsconfig) | [![npm](https://img.shields.io/npm/v/@theholocron/tsconfig)](https://www.npmjs.com/package/@theholocron/tsconfig) | TypeScript base configs (NextJS, node-lts) |
-| [`@theholocron/vite-config`](./packages/vite-config) | [![npm](https://img.shields.io/npm/v/@theholocron/vite-config)](https://www.npmjs.com/package/@theholocron/vite-config) | Vite presets for libraries, React apps, Node tools |
-| [`@theholocron/vitest-config`](./packages/vitest-config) | [![npm](https://img.shields.io/npm/v/@theholocron/vitest-config)](https://www.npmjs.com/package/@theholocron/vitest-config) | Vitest presets and coverage bundles |
-| [`@theholocron/jest-config`](./packages/jest-config) | [![npm](https://img.shields.io/npm/v/@theholocron/jest-config)](https://www.npmjs.com/package/@theholocron/jest-config) | **Deprecated** — use `@theholocron/vitest-config` |
+| Package                                                              | Version                                                                                                                                 | Description                                        |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| [`@theholocron/browserslist-config`](./packages/browserslist-config) | [![npm](https://img.shields.io/npm/v/@theholocron/browserslist-config)](https://www.npmjs.com/package/@theholocron/browserslist-config) | Browser and device targets                         |
+| [`@theholocron/bundlewatch-config`](./packages/bundlewatch-config)   | [![npm](https://img.shields.io/npm/v/@theholocron/bundlewatch-config)](https://www.npmjs.com/package/@theholocron/bundlewatch-config)   | Bundle size monitoring                             |
+| [`@theholocron/commitlint-config`](./packages/commitlint-config)     | [![npm](https://img.shields.io/npm/v/@theholocron/commitlint-config)](https://www.npmjs.com/package/@theholocron/commitlint-config)     | Conventional commit enforcement                    |
+| [`@theholocron/eslint-config`](./packages/eslint-config)             | [![npm](https://img.shields.io/npm/v/@theholocron/eslint-config)](https://www.npmjs.com/package/@theholocron/eslint-config)             | ESLint rules for JS/TS/React/Next/Node             |
+| [`@theholocron/lint-staged-config`](./packages/lint-staged-config)   | [![npm](https://img.shields.io/npm/v/@theholocron/lint-staged-config)](https://www.npmjs.com/package/@theholocron/lint-staged-config)   | Pre-commit lint-staged hooks                       |
+| [`@theholocron/prettier-config`](./packages/prettier-config)         | [![npm](https://img.shields.io/npm/v/@theholocron/prettier-config)](https://www.npmjs.com/package/@theholocron/prettier-config)         | Prettier formatting rules                          |
+| [`@theholocron/storybook-config`](./packages/storybook-config)       | [![npm](https://img.shields.io/npm/v/@theholocron/storybook-config)](https://www.npmjs.com/package/@theholocron/storybook-config)       | Storybook addon and theme setup                    |
+| [`@theholocron/stylelint-config`](./packages/stylelint-config)       | [![npm](https://img.shields.io/npm/v/@theholocron/stylelint-config)](https://www.npmjs.com/package/@theholocron/stylelint-config)       | StyleLint rules for CSS/SCSS                       |
+| [`@theholocron/tsconfig`](./packages/tsconfig)                       | [![npm](https://img.shields.io/npm/v/@theholocron/tsconfig)](https://www.npmjs.com/package/@theholocron/tsconfig)                       | TypeScript base configs (NextJS, node-lts)         |
+| [`@theholocron/vite-config`](./packages/vite-config)                 | [![npm](https://img.shields.io/npm/v/@theholocron/vite-config)](https://www.npmjs.com/package/@theholocron/vite-config)                 | Vite presets for libraries, React apps, Node tools |
+| [`@theholocron/vitest-config`](./packages/vitest-config)             | [![npm](https://img.shields.io/npm/v/@theholocron/vitest-config)](https://www.npmjs.com/package/@theholocron/vitest-config)             | Vitest presets and coverage bundles                |
+| [`@theholocron/jest-config`](./packages/jest-config)                 | [![npm](https://img.shields.io/npm/v/@theholocron/jest-config)](https://www.npmjs.com/package/@theholocron/jest-config)                 | **Deprecated** — use `@theholocron/vitest-config`  |
 
 ## Development
 

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -7,11 +7,6 @@ export default defineConfig({
 		repo: "theholocron/configs",
 		repoPolicy: {
 			preset: "strict",
-			requiredChecks: [
-				"DCO",
-				"Lint / Lint",
-				"Review / Review PRs",
-			],
 		},
 		workflows: [
 			"lint",

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from "@theholocron/cli";
 export default defineConfig({
 	project: {
 		name: "configs",
-		description: "Shared configuration packages for the theholocron organization.",
+		description:
+			"Shared configuration packages for the theholocron organization.",
 		repo: "theholocron/configs",
 		repoPolicy: {
 			preset: "strict",
@@ -22,6 +23,14 @@ export default defineConfig({
 	providers: {
 		source: "github",
 		ci: "github",
-		issues: ["github", { labels: { inProgress: "status:in-progress", inReview: "status:in-review" } }],
+		issues: [
+			"github",
+			{
+				labels: {
+					inProgress: "status:in-progress",
+					inReview: "status:in-review",
+				},
+			},
+		],
 	},
 });

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.9",
     "@theholocron/cli": "catalog:holocron",
+    "@theholocron/commitlint-config": "workspace:*",
     "@theholocron/eslint-config": "workspace:*",
     "@theholocron/holocron-plugin-github": "catalog:holocron",
     "conventional-changelog-conventionalcommits": "^10.2.1",

--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # Browserslist Config
 
 A [browserslist configuration](https://github.com/browserslist/browserslist#shareable-configs) defining the browsers and devices supported by theholocron projects.
@@ -15,7 +16,7 @@ In your project `package.json`:
 
 ```json
 {
-  "browserslist": ["extends @theholocron/browserslist-config"]
+	"browserslist": ["extends @theholocron/browserslist-config"]
 }
 ```
 

--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -1,3 +1,4 @@
+<!-- editorconfig-checker-disable-file -->
 # Browserslist Config
 
 A [browserslist configuration](https://github.com/browserslist/browserslist#shareable-configs) defining the browsers and devices supported by theholocron projects.

--- a/packages/bundlewatch-config/README.md
+++ b/packages/bundlewatch-config/README.md
@@ -1,3 +1,4 @@
+<!-- editorconfig-checker-disable-file -->
 # Bundlewatch Config
 
 A [Bundlewatch configuration](https://bundlewatch.io/#/reference/configuration) for monitoring bundle size in libraries.

--- a/packages/bundlewatch-config/README.md
+++ b/packages/bundlewatch-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # Bundlewatch Config
 
 A [Bundlewatch configuration](https://bundlewatch.io/#/reference/configuration) for monitoring bundle size in libraries.
@@ -15,9 +16,9 @@ Add the following script to your project `package.json`:
 
 ```json
 {
-  "scripts": {
-    "audit:bundle": "bundlewatch --config ./node_modules/@theholocron/bundlewatch-config/bundlewatch.config.js"
-  }
+	"scripts": {
+		"audit:bundle": "bundlewatch --config ./node_modules/@theholocron/bundlewatch-config/bundlewatch.config.js"
+	}
 }
 ```
 

--- a/packages/commitlint-config/README.md
+++ b/packages/commitlint-config/README.md
@@ -1,3 +1,4 @@
+<!-- editorconfig-checker-disable-file -->
 # CommitLint Config
 
 A [CommitLint configuration](https://commitlint.js.org/reference/configuration.html#shareable-configuration) for writing well-formatted and consistent Git commits.

--- a/packages/commitlint-config/README.md
+++ b/packages/commitlint-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # CommitLint Config
 
 A [CommitLint configuration](https://commitlint.js.org/reference/configuration.html#shareable-configuration) for writing well-formatted and consistent Git commits.
@@ -17,7 +18,7 @@ In your project `commitlint.config.js`:
 
 ```javascript
 export default {
-  extends: ["@theholocron/commitlint-config"],
+	extends: ["@theholocron/commitlint-config"],
 };
 ```
 

--- a/packages/eslint-config/bundles/node-app.js
+++ b/packages/eslint-config/bundles/node-app.js
@@ -4,10 +4,5 @@ import { typescript } from "../configs/typescript.js";
 import { vitest } from "../configs/vitest.js";
 
 export function nodeApp() {
-	return [
-		...base(),
-		...node(),
-		...typescript(),
-		...vitest(),
-	];
+	return [...base(), ...node(), ...typescript(), ...vitest()];
 }

--- a/packages/eslint-config/configs/cypress.js
+++ b/packages/eslint-config/configs/cypress.js
@@ -5,9 +5,7 @@ export function cypressConfig() {
 		{
 			name: "@theholocron/cypress",
 			files: ["cypress/**/*.{js,ts,jsx,tsx}"],
-			extends: [
-				cypress.configs.recommended,
-			],
+			extends: [cypress.configs.recommended],
 		},
 	];
 }

--- a/packages/eslint-config/configs/react.js
+++ b/packages/eslint-config/configs/react.js
@@ -1,10 +1,7 @@
 import react from "eslint-plugin-react";
 
 export function reactConfig() {
-	return [
-		react.configs.flat.recommended,
-		react.configs.flat["jsx-runtime"],
-	];
+	return [react.configs.flat.recommended, react.configs.flat["jsx-runtime"]];
 }
 
 export { reactConfig as react };

--- a/packages/eslint-config/configs/typescript.js
+++ b/packages/eslint-config/configs/typescript.js
@@ -14,6 +14,6 @@ export function typescript() {
 					},
 				],
 			},
-		}
+		},
 	];
 }

--- a/packages/jest-config/README.md
+++ b/packages/jest-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # Jest Config — Deprecated
 
 > **This package is deprecated.** New projects should use
@@ -40,9 +41,9 @@ In your project `package.json`:
 
 ```json
 {
-  "jest": {
-    "displayName": "<project>",
-    "preset": "@theholocron/jest-config"
-  }
+	"jest": {
+		"displayName": "<project>",
+		"preset": "@theholocron/jest-config"
+	}
 }
 ```

--- a/packages/jest-config/README.md
+++ b/packages/jest-config/README.md
@@ -1,3 +1,4 @@
+<!-- editorconfig-checker-disable-file -->
 # Jest Config — Deprecated
 
 > **This package is deprecated.** New projects should use

--- a/packages/lint-staged-config/README.md
+++ b/packages/lint-staged-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # Lint Staged Config
 
 A [lint-staged configuration](https://github.com/lint-staged/lint-staged#configuration) for running linters on Git-staged files.
@@ -29,18 +30,18 @@ Or add it to `package.json`:
 
 ```json
 {
-  "lint-staged": "node_modules/@theholocron/lint-staged-config/lint-staged.config.js"
+	"lint-staged": "node_modules/@theholocron/lint-staged-config/lint-staged.config.js"
 }
 ```
 
 ## What runs on staged files
 
-| File pattern | Commands |
-|---|---|
-| `*.{js,jsx}` | `prettier --write`, `eslint` |
-| `*.{ts,tsx}` | `prettier --write`, `eslint`, `tsc-files --noEmit` |
-| `*.css` | `stylelint --fix` |
-| `*.scss` | `stylelint --syntax=scss --fix` |
-| `*.{md,mdx}` | `prettier --write` |
-| `*.{png,jpeg,jpg,gif,svg}` | `imagemin-lint-staged` |
-| `package.json` | `sort-package-json` |
+| File pattern               | Commands                                           |
+| -------------------------- | -------------------------------------------------- |
+| `*.{js,jsx}`               | `prettier --write`, `eslint`                       |
+| `*.{ts,tsx}`               | `prettier --write`, `eslint`, `tsc-files --noEmit` |
+| `*.css`                    | `stylelint --fix`                                  |
+| `*.scss`                   | `stylelint --syntax=scss --fix`                    |
+| `*.{md,mdx}`               | `prettier --write`                                 |
+| `*.{png,jpeg,jpg,gif,svg}` | `imagemin-lint-staged`                             |
+| `package.json`             | `sort-package-json`                                |

--- a/packages/lint-staged-config/README.md
+++ b/packages/lint-staged-config/README.md
@@ -1,3 +1,4 @@
+<!-- editorconfig-checker-disable-file -->
 # Lint Staged Config
 
 A [lint-staged configuration](https://github.com/lint-staged/lint-staged#configuration) for running linters on Git-staged files.

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # Prettier Config
 
 A [Prettier configuration](https://prettier.io/docs/en/configuration) for consistent code formatting.
@@ -15,7 +16,7 @@ In your project `package.json`:
 
 ```json
 {
-  "prettier": "@theholocron/prettier-config"
+	"prettier": "@theholocron/prettier-config"
 }
 ```
 

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,3 +1,4 @@
+<!-- editorconfig-checker-disable-file -->
 # Prettier Config
 
 A [Prettier configuration](https://prettier.io/docs/en/configuration) for consistent code formatting.

--- a/packages/storybook-config/README.md
+++ b/packages/storybook-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # Storybook Config
 
 A [Storybook configuration](https://storybook.js.org/docs/configure) with addons and theme setup for React component libraries.

--- a/packages/storybook-config/README.md
+++ b/packages/storybook-config/README.md
@@ -1,3 +1,4 @@
+<!-- editorconfig-checker-disable-file -->
 # Storybook Config
 
 A [Storybook configuration](https://storybook.js.org/docs/configure) with addons and theme setup for React component libraries.

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -1,3 +1,4 @@
+<!-- editorconfig-checker-disable-file -->
 # TypeScript Config
 
 A [TypeScript configuration](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) for writing typed JavaScript.

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # TypeScript Config
 
 A [TypeScript configuration](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) for writing typed JavaScript.
@@ -17,7 +18,7 @@ In your project `tsconfig.json`, extend one of the two base configurations:
 
 ```json
 {
-  "extends": "@theholocron/tsconfig/nextjs"
+	"extends": "@theholocron/tsconfig/nextjs"
 }
 ```
 
@@ -27,6 +28,6 @@ Targets the current Node LTS feature set. All theholocron projects use this:
 
 ```json
 {
-  "extends": "@theholocron/tsconfig/node-lts"
+	"extends": "@theholocron/tsconfig/node-lts"
 }
 ```

--- a/packages/tsdown-config/README.md
+++ b/packages/tsdown-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # tsdown Config
 
 Shared [tsdown](https://tsdown.dev) configurations for `@theholocron` packages.
@@ -25,6 +26,6 @@ To customise entry points or other options, use the `library()` factory:
 import { library } from "@theholocron/tsdown-config/presets/library";
 
 export default library({
-  entry: ["src/index.ts", "src/capabilities/index.ts"],
+	entry: ["src/index.ts", "src/capabilities/index.ts"],
 });
 ```

--- a/packages/tsdown-config/README.md
+++ b/packages/tsdown-config/README.md
@@ -1,3 +1,4 @@
+<!-- editorconfig-checker-disable-file -->
 # tsdown Config
 
 Shared [tsdown](https://tsdown.dev) configurations for `@theholocron` packages.

--- a/packages/vite-config/README.md
+++ b/packages/vite-config/README.md
@@ -20,7 +20,9 @@ Outputs ESM only; externalises `react` and `react-dom` by default. Returns a `Pr
 import { defineConfig } from "vite";
 import { library } from "@theholocron/vite-config/library";
 
-export default defineConfig(await library({ entry: "src/index.ts", name: "MyLib" }));
+export default defineConfig(
+	await library({ entry: "src/index.ts", name: "MyLib" }),
+);
 ```
 
 ### React single-page application

--- a/packages/vite-config/presets/get-package-name.js
+++ b/packages/vite-config/presets/get-package-name.js
@@ -3,7 +3,11 @@ import { resolve } from "node:path";
 
 export function getPackageName() {
 	try {
-		return JSON.parse(readFileSync(resolve(process.cwd(), "package.json"), "utf-8")).name ?? "unknown";
+		return (
+			JSON.parse(
+				readFileSync(resolve(process.cwd(), "package.json"), "utf-8"),
+			).name ?? "unknown"
+		);
 	} catch {
 		return "unknown";
 	}

--- a/packages/vite-config/presets/library.js
+++ b/packages/vite-config/presets/library.js
@@ -13,7 +13,12 @@ import { getPackageName } from "./get-package-name.js";
  * @param {import('vite').UserConfig} [options.overrides={}] Merged last
  * @returns {Promise<import('vite').UserConfig>}
  */
-export async function library({ entry = "src/index.ts", name, external = [], overrides = {} } = {}) {
+export async function library({
+	entry = "src/index.ts",
+	name,
+	external = [],
+	overrides = {},
+} = {}) {
 	const plugins = [];
 	try {
 		const { codecovVitePlugin } = await import("@codecov/vite-plugin");

--- a/packages/vitest-config/README.md
+++ b/packages/vitest-config/README.md
@@ -69,6 +69,6 @@ export default defineConfig({ test: reactApp().test });
 
 We use [Vitest](https://vitest.dev/) as our testing framework with the following conventions:
 
--   **Coverage**: enforced at 80% on lines, branches, functions, and statements via `@vitest/coverage-v8`
--   **File naming**: test files use the `.test.{js,ts}` or `.spec.{js,ts}` suffix, co-located with source
--   **Stories excluded**: `*.{story,stories}.*` files are excluded from unit test runs; use the `storybook` preset for those
+- **Coverage**: enforced at 80% on lines, branches, functions, and statements via `@vitest/coverage-v8`
+- **File naming**: test files use the `.test.{js,ts}` or `.spec.{js,ts}` suffix, co-located with source
+- **Stories excluded**: `*.{story,stories}.*` files are excluded from unit test runs; use the `storybook` preset for those

--- a/packages/vitest-config/presets/storybook.js
+++ b/packages/vitest-config/presets/storybook.js
@@ -7,7 +7,8 @@
  * @returns {import('vitest/config').UserProjectConfig}
  */
 export async function storybook(storybookDir = ".storybook", options = {}) {
-	const { storybookTest } = await import("@storybook/addon-vitest/vitest-plugin");
+	const { storybookTest } =
+		await import("@storybook/addon-vitest/vitest-plugin");
 
 	return {
 		plugins: [storybookTest({ storybookDir })],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@theholocron/cli':
         specifier: catalog:holocron
         version: 2.0.0-alpha.27
+      '@theholocron/commitlint-config':
+        specifier: workspace:*
+        version: link:packages/commitlint-config
       '@theholocron/eslint-config':
         specifier: workspace:*
         version: link:packages/eslint-config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   holocron:
     '@theholocron/cli':
-      specifier: 2.0.0-alpha.22
-      version: 2.0.0-alpha.22
+      specifier: 2.0.0-alpha.27
+      version: 2.0.0-alpha.27
     '@theholocron/holocron-plugin-github':
-      specifier: 2.0.0-alpha.22
-      version: 2.0.0-alpha.22
+      specifier: 2.0.0-alpha.27
+      version: 2.0.0-alpha.27
 
 importers:
 
@@ -37,13 +37,13 @@ importers:
         version: 12.0.9(semantic-release@25.0.6(typescript@5.9.3))
       '@theholocron/cli':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.22
+        version: 2.0.0-alpha.27
       '@theholocron/eslint-config':
         specifier: workspace:*
         version: link:packages/eslint-config
       '@theholocron/holocron-plugin-github':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.22(@theholocron/cli@2.0.0-alpha.22)
+        version: 2.0.0-alpha.27(@theholocron/cli@2.0.0-alpha.27)
       conventional-changelog-conventionalcommits:
         specifier: ^10.2.1
         version: 10.2.1
@@ -223,7 +223,7 @@ importers:
         version: 38.0.0(stylelint@16.26.1(typescript@5.9.3))
       stylelint-config-standard-scss:
         specifier: ^15
-        version: 15.0.1(postcss@8.5.16)(stylelint@16.26.1(typescript@5.9.3))
+        version: 15.0.1(postcss@8.5.19)(stylelint@16.26.1(typescript@5.9.3))
 
   packages/tsconfig:
     dependencies:
@@ -2049,14 +2049,14 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@theholocron/cli@2.0.0-alpha.22':
-    resolution: {integrity: sha512-oLJOB0vTkZwAIvEVUf2y5btGRYEX9MqbA8lavpn8VZUe1nG+Y8ScEJF/PZxWOgvW1WEWklNOVq9OQBDnzeatAQ==}
+  '@theholocron/cli@2.0.0-alpha.27':
+    resolution: {integrity: sha512-SDkX1FO+ocngUu7ez52KL5oqj9c4xQrRSIy7Q7hN4ncliySyiNEnNqnQOxMMPQQdOIiE86pjZWZMW/1Vb+uweg==}
     hasBin: true
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.22':
-    resolution: {integrity: sha512-evzHzMHIz8KWJaTWtnPoeBt3STtd3zTRXRCRWA4VgSYeTIdSeU7UYa6ooOjqsASQ5hzpPwjbLIF9p6wKNe4eJw==}
+  '@theholocron/holocron-plugin-github@2.0.0-alpha.27':
+    resolution: {integrity: sha512-0t+ApM2dhwZMlohTrxXEDUUXjojnbsKUxEU0qv1oXoykwV4jSLcXusd9KPJezt1pYDIawhfFP7KoAUmzVrgEbw==}
     peerDependencies:
-      '@theholocron/cli': 2.0.0-alpha.22
+      '@theholocron/cli': 2.0.0-alpha.27
 
   '@theholocron/http-client@0.1.0':
     resolution: {integrity: sha512-ul45D9F1nQmfbQ5x6Q4zQT20mBnmCZ7HmpSpXWvQPAf0kI8pZfd7rvpuc2fkXBI7w5uDfH+KFoaCGpzL+HDyoA==}
@@ -5419,6 +5419,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -5965,6 +5970,10 @@ packages:
 
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -9304,16 +9313,16 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@theholocron/cli@2.0.0-alpha.22':
+  '@theholocron/cli@2.0.0-alpha.27':
     dependencies:
       '@napi-rs/keyring': 1.3.0
       '@theholocron/http-client': 0.1.0
       tsx: 4.23.1
       yargs: 18.0.0
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.22(@theholocron/cli@2.0.0-alpha.22)':
+  '@theholocron/holocron-plugin-github@2.0.0-alpha.27(@theholocron/cli@2.0.0-alpha.27)':
     dependencies:
-      '@theholocron/cli': 2.0.0-alpha.22
+      '@theholocron/cli': 2.0.0-alpha.27
       libsodium-wrappers: 0.7.16
 
   '@theholocron/http-client@0.1.0': {}
@@ -13237,6 +13246,8 @@ snapshots:
 
   nanoid@3.3.15: {}
 
+  nanoid@3.3.16: {}
+
   natural-compare@1.4.0: {}
 
   neo-async@2.6.2: {}
@@ -13689,9 +13700,9 @@ snapshots:
     dependencies:
       postcss: 8.5.16
 
-  postcss-scss@4.0.9(postcss@8.5.16):
+  postcss-scss@4.0.9(postcss@8.5.19):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.19
 
   postcss-selector-parser@7.1.4:
     dependencies:
@@ -13703,6 +13714,12 @@ snapshots:
   postcss@8.5.16:
     dependencies:
       nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.19:
+    dependencies:
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -14583,26 +14600,26 @@ snapshots:
 
   strnum@1.1.2: {}
 
-  stylelint-config-recommended-scss@15.0.1(postcss@8.5.16)(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-recommended-scss@15.0.1(postcss@8.5.19)(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
-      postcss-scss: 4.0.9(postcss@8.5.16)
+      postcss-scss: 4.0.9(postcss@8.5.19)
       stylelint: 16.26.1(typescript@5.9.3)
       stylelint-config-recommended: 16.0.0(stylelint@16.26.1(typescript@5.9.3))
       stylelint-scss: 6.14.0(stylelint@16.26.1(typescript@5.9.3))
     optionalDependencies:
-      postcss: 8.5.16
+      postcss: 8.5.19
 
   stylelint-config-recommended@16.0.0(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
       stylelint: 16.26.1(typescript@5.9.3)
 
-  stylelint-config-standard-scss@15.0.1(postcss@8.5.16)(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-standard-scss@15.0.1(postcss@8.5.19)(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
       stylelint: 16.26.1(typescript@5.9.3)
-      stylelint-config-recommended-scss: 15.0.1(postcss@8.5.16)(stylelint@16.26.1(typescript@5.9.3))
+      stylelint-config-recommended-scss: 15.0.1(postcss@8.5.19)(stylelint@16.26.1(typescript@5.9.3))
       stylelint-config-standard: 38.0.0(stylelint@16.26.1(typescript@5.9.3))
     optionalDependencies:
-      postcss: 8.5.16
+      postcss: 8.5.19
 
   stylelint-config-standard@38.0.0(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
@@ -15121,7 +15138,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.16
+      postcss: 8.5.19
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,5 +4,5 @@ packages:
 # Holocron CLI and plugins — pinned in lockstep; bump together when running setup.
 catalogs:
   holocron:
-    '@theholocron/cli': 2.0.0-alpha.22
-    '@theholocron/holocron-plugin-github': 2.0.0-alpha.22
+    '@theholocron/cli': 2.0.0-alpha.27
+    '@theholocron/holocron-plugin-github': 2.0.0-alpha.27


### PR DESCRIPTION
## Summary

- Installs `@theholocron/cli` and `@theholocron/holocron-plugin-github` under `catalogs.holocron` in `pnpm-workspace.yaml` (alpha.27)
- Removes manual `requiredChecks` from `holocron.config.ts` — now auto-derived from the configured workflows list by `holocron setup`
- Adds generated `.github/labeler.yml` — maps Conventional Commit type prefixes to standard GitHub label names for the `bookkeeping-pr` reusable workflow

## Test plan

- [ ] `pnpm install --frozen-lockfile` succeeds
- [ ] Bookkeeping check passes (labeler.yml is now in the correct `github/issue-labeler` format)
- [ ] Ruleset required status checks are correct (auto-derived: `DCO` + `Lint / Lint entire codebase`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->