### PR TITLE
chore: bump holocron to alpha.34 and re-sync

### DIFF
--- a/.claude/skills/configs-package.md
+++ b/.claude/skills/configs-package.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # configs-package
 
 Scaffold a new shareable config package in `theholocron/configs`.
@@ -100,7 +101,7 @@ Follow this structure (see existing READMEs for tone):
 ```markdown
 # <Tool> Config
 
-A [<Tool> configuration](<official-docs-url>) for <one-line description>.
+A [<Tool> configuration](official-docs-url) for <one-line description>.
 
 ## Installation
 

--- a/.claude/skills/configs-package.md
+++ b/.claude/skills/configs-package.md
@@ -1,5 +1,4 @@
 <!-- editorconfig-checker-disable-file -->
-
 # configs-package
 
 Scaffold a new shareable config package in `theholocron/configs`.
@@ -42,34 +41,34 @@ Key fields:
 
 ```json
 {
-	"name": "@theholocron/<tool>-config",
-	"version": "4.1.0",
-	"description": "A <Tool> configuration for <purpose>.",
-	"homepage": "https://github.com/theholocron/configs/tree/main/packages/<tool>-config#readme",
-	"bugs": "https://github.com/theholocron/configs/issues",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/theholocron/configs.git"
-	},
-	"license": "GPL-3.0",
-	"author": "Newton Koumantzelis",
-	"type": "module",
-	"exports": {
-		".": { "import": "./index.js", "default": "./index.js" }
-	},
-	"files": ["index.js"],
-	"peerDependencies": {
-		"<tool>": "^<major>"
-	},
-	"publishConfig": { "access": "public" }
+  "name": "@theholocron/<tool>-config",
+  "version": "4.1.0",
+  "description": "A <Tool> configuration for <purpose>.",
+  "homepage": "https://github.com/theholocron/configs/tree/main/packages/<tool>-config#readme",
+  "bugs": "https://github.com/theholocron/configs/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/configs.git"
+  },
+  "license": "GPL-3.0",
+  "author": "Newton Koumantzelis",
+  "type": "module",
+  "exports": {
+    ".": { "import": "./index.js", "default": "./index.js" }
+  },
+  "files": ["index.js"],
+  "peerDependencies": {
+    "<tool>": "^<major>"
+  },
+  "publishConfig": { "access": "public" }
 }
 ```
 
 - Match `version` to the current monorepo version (check the root `package.json`).
 - All peer deps that are optional per-preset go under `peerDependenciesMeta`:
-    ```json
-    "peerDependenciesMeta": { "<tool>": { "optional": true } }
-    ```
+  ```json
+  "peerDependenciesMeta": { "<tool>": { "optional": true } }
+  ```
 - Export each preset/bundle as a subpath (`"./presets/node"`, `"./bundles/library"`, …)
   and add those to `"files"`.
 
@@ -81,7 +80,7 @@ Key fields:
  * @type {import("<tool>").Config}
  */
 const config = {
-	// ...
+  // ...
 };
 
 export default config;
@@ -101,7 +100,7 @@ Follow this structure (see existing READMEs for tone):
 ```markdown
 # <Tool> Config
 
-A [<Tool> configuration](official-docs-url) for <one-line description>.
+A [<Tool> configuration](<official-docs-url>) for <one-line description>.
 
 ## Installation
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,8 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+indent_style = space
+indent_size = 2
 
 [.*{rc,ignore}]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,9 @@
+# AUTO-GENERATED — do not edit directly.
+# Source:  theholocron/holocron · packages/cli/src/commands/setup.ts
+# Synced:  2026-07-14T22:01:44.676Z
+# Tool:    holocron setup
+# Changes: run `holocron setup` to regenerate.
+
 root = true
 
 [*]

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -6,7 +6,10 @@
   "IgnoreDefaults": false,
   "SpacesAfterTabs": false,
   "NoColor": false,
-  "Exclude": ["(^|.+/)LICENSE$", "^public/.*"],
+  "Exclude": [
+    "(^|.+/)LICENSE$",
+    "^public/.*"
+  ],
   "AllowedContentTypes": [],
   "PassedFiles": [],
   "Disable": {

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup.ts
-# Synced:  2026-07-14T05:02:27.113Z
+# Synced:  2026-07-14T21:56:15.359Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup.ts
-# Synced:  2026-07-14T21:56:15.359Z
+# Synced:  2026-07-14T22:01:44.675Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 

--- a/.github/workflows/bookkeeping-pr.yml
+++ b/.github/workflows/bookkeeping-pr.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T05:02:27.112Z
+# Synced:  2026-07-14T21:56:15.359Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: PR Bookkeeping

--- a/.github/workflows/bookkeeping-pr.yml
+++ b/.github/workflows/bookkeeping-pr.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T21:56:15.359Z
+# Synced:  2026-07-14T22:01:44.675Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: PR Bookkeeping

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T21:56:15.356Z
+# Synced:  2026-07-14T22:01:44.671Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T05:02:27.107Z
+# Synced:  2026-07-14T21:56:15.356Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: CodeQL

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T05:02:27.111Z
+# Synced:  2026-07-14T21:56:15.358Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Dependencies

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T21:56:15.358Z
+# Synced:  2026-07-14T22:01:44.675Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Dependencies

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T21:56:15.358Z
+# Synced:  2026-07-14T22:01:44.674Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Greetings

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T05:02:27.110Z
+# Synced:  2026-07-14T21:56:15.358Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Greetings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T05:02:27.104Z
+# Synced:  2026-07-14T21:56:15.354Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T21:56:15.354Z
+# Synced:  2026-07-14T22:01:44.669Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T05:02:27.109Z
+# Synced:  2026-07-14T21:56:15.357Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T21:56:15.357Z
+# Synced:  2026-07-14T22:01:44.673Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Release

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T05:02:27.108Z
+# Synced:  2026-07-14T21:56:15.357Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Review

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T21:56:15.357Z
+# Synced:  2026-07-14T22:01:44.672Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Review

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T21:56:15.358Z
+# Synced:  2026-07-14T22:01:44.674Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-14T05:02:27.109Z
+# Synced:  2026-07-14T21:56:15.358Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Stale

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,4 @@
 <!-- editorconfig-checker-disable-file -->
-
 @../github-private/CLAUDE.md
 
 # CLAUDE.md
@@ -44,10 +43,10 @@ Use the `.claude/skills/configs-package.md` skill, which scaffolds the full
 package. Quick checklist:
 
 1. Create `packages/<tool>-config/` with:
-    - `package.json` — follow the shape of an existing package; include all
-      relevant `peerDependencies` as optional where the tool itself is optional
-    - `index.js` — default export or named export(s) of the config object
-    - `README.md` — Installation + Usage sections; see existing packages for tone
+   - `package.json` — follow the shape of an existing package; include all
+     relevant `peerDependencies` as optional where the tool itself is optional
+   - `index.js` — default export or named export(s) of the config object
+   - `README.md` — Installation + Usage sections; see existing packages for tone
 2. Add the package to `pnpm-workspace.yaml` if it is not auto-discovered.
 3. Verify `pnpm install` resolves and `pnpm lint` passes (ESLint config lints itself).
 4. Open a PR with a `feat:` commit — semantic-release will compute a minor bump

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 @../github-private/CLAUDE.md
 
 # CLAUDE.md

--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # Browserslist Config
 
 A [browserslist configuration](https://github.com/browserslist/browserslist#shareable-configs) defining the browsers and devices supported by theholocron projects.

--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -1,5 +1,4 @@
 <!-- editorconfig-checker-disable-file -->
-
 # Browserslist Config
 
 A [browserslist configuration](https://github.com/browserslist/browserslist#shareable-configs) defining the browsers and devices supported by theholocron projects.
@@ -16,7 +15,7 @@ In your project `package.json`:
 
 ```json
 {
-	"browserslist": ["extends @theholocron/browserslist-config"]
+  "browserslist": ["extends @theholocron/browserslist-config"]
 }
 ```
 

--- a/packages/bundlewatch-config/README.md
+++ b/packages/bundlewatch-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # Bundlewatch Config
 
 A [Bundlewatch configuration](https://bundlewatch.io/#/reference/configuration) for monitoring bundle size in libraries.

--- a/packages/bundlewatch-config/README.md
+++ b/packages/bundlewatch-config/README.md
@@ -1,5 +1,4 @@
 <!-- editorconfig-checker-disable-file -->
-
 # Bundlewatch Config
 
 A [Bundlewatch configuration](https://bundlewatch.io/#/reference/configuration) for monitoring bundle size in libraries.
@@ -16,9 +15,9 @@ Add the following script to your project `package.json`:
 
 ```json
 {
-	"scripts": {
-		"audit:bundle": "bundlewatch --config ./node_modules/@theholocron/bundlewatch-config/bundlewatch.config.js"
-	}
+  "scripts": {
+    "audit:bundle": "bundlewatch --config ./node_modules/@theholocron/bundlewatch-config/bundlewatch.config.js"
+  }
 }
 ```
 

--- a/packages/commitlint-config/README.md
+++ b/packages/commitlint-config/README.md
@@ -1,5 +1,4 @@
 <!-- editorconfig-checker-disable-file -->
-
 # CommitLint Config
 
 A [CommitLint configuration](https://commitlint.js.org/reference/configuration.html#shareable-configuration) for writing well-formatted and consistent Git commits.
@@ -18,7 +17,7 @@ In your project `commitlint.config.js`:
 
 ```javascript
 export default {
-	extends: ["@theholocron/commitlint-config"],
+  extends: ["@theholocron/commitlint-config"],
 };
 ```
 

--- a/packages/commitlint-config/README.md
+++ b/packages/commitlint-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # CommitLint Config
 
 A [CommitLint configuration](https://commitlint.js.org/reference/configuration.html#shareable-configuration) for writing well-formatted and consistent Git commits.

--- a/packages/commitlint-config/commitlint.config.js
+++ b/packages/commitlint-config/commitlint.config.js
@@ -4,6 +4,7 @@
  */
 const config = {
 	extends: ["@commitlint/config-conventional"],
+	ignores: [(message) => /^chore\(deps(-dev)?\): Bump/.test(message)],
 };
 
 export default config;

--- a/packages/jest-config/README.md
+++ b/packages/jest-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # Jest Config — Deprecated
 
 > **This package is deprecated.** New projects should use

--- a/packages/jest-config/README.md
+++ b/packages/jest-config/README.md
@@ -1,5 +1,4 @@
 <!-- editorconfig-checker-disable-file -->
-
 # Jest Config — Deprecated
 
 > **This package is deprecated.** New projects should use
@@ -41,9 +40,9 @@ In your project `package.json`:
 
 ```json
 {
-	"jest": {
-		"displayName": "<project>",
-		"preset": "@theholocron/jest-config"
-	}
+  "jest": {
+    "displayName": "<project>",
+    "preset": "@theholocron/jest-config"
+  }
 }
 ```

--- a/packages/lint-staged-config/README.md
+++ b/packages/lint-staged-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # Lint Staged Config
 
 A [lint-staged configuration](https://github.com/lint-staged/lint-staged#configuration) for running linters on Git-staged files.
@@ -35,12 +36,12 @@ Or add it to `package.json`:
 
 ## What runs on staged files
 
-| File pattern | Commands |
-|---|---|
-| `*.{js,jsx}` | `prettier --write`, `eslint` |
-| `*.{ts,tsx}` | `prettier --write`, `eslint`, `tsc-files --noEmit` |
-| `*.css` | `stylelint --fix` |
-| `*.scss` | `stylelint --syntax=scss --fix` |
-| `*.{md,mdx}` | `prettier --write` |
-| `*.{png,jpeg,jpg,gif,svg}` | `imagemin-lint-staged` |
-| `package.json` | `sort-package-json` |
+| File pattern               | Commands                                           |
+| -------------------------- | -------------------------------------------------- |
+| `*.{js,jsx}`               | `prettier --write`, `eslint`                       |
+| `*.{ts,tsx}`               | `prettier --write`, `eslint`, `tsc-files --noEmit` |
+| `*.css`                    | `stylelint --fix`                                  |
+| `*.scss`                   | `stylelint --syntax=scss --fix`                    |
+| `*.{md,mdx}`               | `prettier --write`                                 |
+| `*.{png,jpeg,jpg,gif,svg}` | `imagemin-lint-staged`                             |
+| `package.json`             | `sort-package-json`                                |

--- a/packages/lint-staged-config/README.md
+++ b/packages/lint-staged-config/README.md
@@ -1,5 +1,4 @@
 <!-- editorconfig-checker-disable-file -->
-
 # Lint Staged Config
 
 A [lint-staged configuration](https://github.com/lint-staged/lint-staged#configuration) for running linters on Git-staged files.
@@ -30,18 +29,18 @@ Or add it to `package.json`:
 
 ```json
 {
-	"lint-staged": "node_modules/@theholocron/lint-staged-config/lint-staged.config.js"
+  "lint-staged": "node_modules/@theholocron/lint-staged-config/lint-staged.config.js"
 }
 ```
 
 ## What runs on staged files
 
-| File pattern               | Commands                                           |
-| -------------------------- | -------------------------------------------------- |
-| `*.{js,jsx}`               | `prettier --write`, `eslint`                       |
-| `*.{ts,tsx}`               | `prettier --write`, `eslint`, `tsc-files --noEmit` |
-| `*.css`                    | `stylelint --fix`                                  |
-| `*.scss`                   | `stylelint --syntax=scss --fix`                    |
-| `*.{md,mdx}`               | `prettier --write`                                 |
-| `*.{png,jpeg,jpg,gif,svg}` | `imagemin-lint-staged`                             |
-| `package.json`             | `sort-package-json`                                |
+| File pattern | Commands |
+|---|---|
+| `*.{js,jsx}` | `prettier --write`, `eslint` |
+| `*.{ts,tsx}` | `prettier --write`, `eslint`, `tsc-files --noEmit` |
+| `*.css` | `stylelint --fix` |
+| `*.scss` | `stylelint --syntax=scss --fix` |
+| `*.{md,mdx}` | `prettier --write` |
+| `*.{png,jpeg,jpg,gif,svg}` | `imagemin-lint-staged` |
+| `package.json` | `sort-package-json` |

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # Prettier Config
 
 A [Prettier configuration](https://prettier.io/docs/en/configuration) for consistent code formatting.
@@ -15,7 +16,7 @@ In your project `package.json`:
 
 ```json
 {
-  "prettier": "@theholocron/prettier-config"
+	"prettier": "@theholocron/prettier-config"
 }
 ```
 

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,5 +1,4 @@
 <!-- editorconfig-checker-disable-file -->
-
 # Prettier Config
 
 A [Prettier configuration](https://prettier.io/docs/en/configuration) for consistent code formatting.
@@ -16,7 +15,7 @@ In your project `package.json`:
 
 ```json
 {
-	"prettier": "@theholocron/prettier-config"
+  "prettier": "@theholocron/prettier-config"
 }
 ```
 

--- a/packages/storybook-config/README.md
+++ b/packages/storybook-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # Storybook Config
 
 A [Storybook configuration](https://storybook.js.org/docs/configure) with addons and theme setup for React component libraries.

--- a/packages/storybook-config/README.md
+++ b/packages/storybook-config/README.md
@@ -1,5 +1,4 @@
 <!-- editorconfig-checker-disable-file -->
-
 # Storybook Config
 
 A [Storybook configuration](https://storybook.js.org/docs/configure) with addons and theme setup for React component libraries.

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -1,5 +1,4 @@
 <!-- editorconfig-checker-disable-file -->
-
 # TypeScript Config
 
 A [TypeScript configuration](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) for writing typed JavaScript.
@@ -18,7 +17,7 @@ In your project `tsconfig.json`, extend one of the two base configurations:
 
 ```json
 {
-	"extends": "@theholocron/tsconfig/nextjs"
+  "extends": "@theholocron/tsconfig/nextjs"
 }
 ```
 
@@ -28,6 +27,6 @@ Targets the current Node LTS feature set. All theholocron projects use this:
 
 ```json
 {
-	"extends": "@theholocron/tsconfig/node-lts"
+  "extends": "@theholocron/tsconfig/node-lts"
 }
 ```

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # TypeScript Config
 
 A [TypeScript configuration](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) for writing typed JavaScript.

--- a/packages/tsdown-config/README.md
+++ b/packages/tsdown-config/README.md
@@ -1,4 +1,5 @@
 <!-- editorconfig-checker-disable-file -->
+
 # tsdown Config
 
 Shared [tsdown](https://tsdown.dev) configurations for `@theholocron` packages.

--- a/packages/tsdown-config/README.md
+++ b/packages/tsdown-config/README.md
@@ -1,5 +1,4 @@
 <!-- editorconfig-checker-disable-file -->
-
 # tsdown Config
 
 Shared [tsdown](https://tsdown.dev) configurations for `@theholocron` packages.
@@ -26,6 +25,6 @@ To customise entry points or other options, use the `library()` factory:
 import { library } from "@theholocron/tsdown-config/presets/library";
 
 export default library({
-	entry: ["src/index.ts", "src/capabilities/index.ts"],
+  entry: ["src/index.ts", "src/capabilities/index.ts"],
 });
 ```

--- a/packages/vite-config/README.md
+++ b/packages/vite-config/README.md
@@ -21,7 +21,7 @@ import { defineConfig } from "vite";
 import { library } from "@theholocron/vite-config/library";
 
 export default defineConfig(
-	await library({ entry: "src/index.ts", name: "MyLib" }),
+  await library({ entry: "src/index.ts", name: "MyLib" }),
 );
 ```
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   holocron:
     '@theholocron/cli':
-      specifier: 2.0.0-alpha.34
-      version: 2.0.0-alpha.34
+      specifier: 2.0.0-alpha.35
+      version: 2.0.0-alpha.35
     '@theholocron/holocron-plugin-github':
-      specifier: 2.0.0-alpha.34
-      version: 2.0.0-alpha.34
+      specifier: 2.0.0-alpha.35
+      version: 2.0.0-alpha.35
 
 importers:
 
@@ -37,7 +37,7 @@ importers:
         version: 12.0.9(semantic-release@25.0.6(typescript@5.9.3))
       '@theholocron/cli':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.34
+        version: 2.0.0-alpha.35
       '@theholocron/commitlint-config':
         specifier: workspace:*
         version: link:packages/commitlint-config
@@ -46,7 +46,7 @@ importers:
         version: link:packages/eslint-config
       '@theholocron/holocron-plugin-github':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.34(@theholocron/cli@2.0.0-alpha.34)
+        version: 2.0.0-alpha.35(@theholocron/cli@2.0.0-alpha.35)
       conventional-changelog-conventionalcommits:
         specifier: ^10.2.1
         version: 10.2.1
@@ -2052,14 +2052,14 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@theholocron/cli@2.0.0-alpha.34':
-    resolution: {integrity: sha512-Th9NnOKogK5IcNKhd2UNgcMvWpt243ePrzIE0zfwR+rBo9r9E3qWZp51Zxy21XnH0GpQI3GLWsM6vLla0y5z+A==}
+  '@theholocron/cli@2.0.0-alpha.35':
+    resolution: {integrity: sha512-QbI10tcT9/tW/ZePxNNJwrDAvDZNbwhL4bfaIWeLKq/8VGWhN0m5w2xV4wCwA1Ap69+jIF2EvxUwNhOx2QtNSw==}
     hasBin: true
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.34':
-    resolution: {integrity: sha512-e1iRygwO4UUyJGN5KyrlGl5rJGTcxBzxnT8M/3+Z7RIB3Mdaphuu9qjtgKpbqMsLzQCFEpcPjlx8VfkTM6TL8A==}
+  '@theholocron/holocron-plugin-github@2.0.0-alpha.35':
+    resolution: {integrity: sha512-K9pKt6gV4nxN/wLvyxW5ezURCHnfmZiu/IjrcVnwyNPWBSmP7qCKPLTXUE8H8NEl+SI6HMNj5Qtkpk129Ur5aw==}
     peerDependencies:
-      '@theholocron/cli': 2.0.0-alpha.34
+      '@theholocron/cli': 2.0.0-alpha.35
 
   '@theholocron/http-client@0.1.0':
     resolution: {integrity: sha512-ul45D9F1nQmfbQ5x6Q4zQT20mBnmCZ7HmpSpXWvQPAf0kI8pZfd7rvpuc2fkXBI7w5uDfH+KFoaCGpzL+HDyoA==}
@@ -9316,16 +9316,16 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@theholocron/cli@2.0.0-alpha.34':
+  '@theholocron/cli@2.0.0-alpha.35':
     dependencies:
       '@napi-rs/keyring': 1.3.0
       '@theholocron/http-client': 0.1.0
       tsx: 4.23.1
       yargs: 18.0.0
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.34(@theholocron/cli@2.0.0-alpha.34)':
+  '@theholocron/holocron-plugin-github@2.0.0-alpha.35(@theholocron/cli@2.0.0-alpha.35)':
     dependencies:
-      '@theholocron/cli': 2.0.0-alpha.34
+      '@theholocron/cli': 2.0.0-alpha.35
       libsodium-wrappers: 0.7.16
 
   '@theholocron/http-client@0.1.0': {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       '@theholocron/cli':
         specifier: catalog:holocron
         version: 2.0.0-alpha.27
-      '@theholocron/commitlint-config':
-        specifier: workspace:*
-        version: link:packages/commitlint-config
       '@theholocron/eslint-config':
         specifier: workspace:*
         version: link:packages/eslint-config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@theholocron/cli':
         specifier: catalog:holocron
         version: 2.0.0-alpha.27
+      '@theholocron/commitlint-config':
+        specifier: workspace:*
+        version: link:packages/commitlint-config
       '@theholocron/eslint-config':
         specifier: workspace:*
         version: link:packages/eslint-config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   holocron:
     '@theholocron/cli':
-      specifier: 2.0.0-alpha.27
-      version: 2.0.0-alpha.27
+      specifier: 2.0.0-alpha.34
+      version: 2.0.0-alpha.34
     '@theholocron/holocron-plugin-github':
-      specifier: 2.0.0-alpha.27
-      version: 2.0.0-alpha.27
+      specifier: 2.0.0-alpha.34
+      version: 2.0.0-alpha.34
 
 importers:
 
@@ -37,7 +37,7 @@ importers:
         version: 12.0.9(semantic-release@25.0.6(typescript@5.9.3))
       '@theholocron/cli':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.27
+        version: 2.0.0-alpha.34
       '@theholocron/commitlint-config':
         specifier: workspace:*
         version: link:packages/commitlint-config
@@ -46,7 +46,7 @@ importers:
         version: link:packages/eslint-config
       '@theholocron/holocron-plugin-github':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.27(@theholocron/cli@2.0.0-alpha.27)
+        version: 2.0.0-alpha.34(@theholocron/cli@2.0.0-alpha.34)
       conventional-changelog-conventionalcommits:
         specifier: ^10.2.1
         version: 10.2.1
@@ -2052,14 +2052,14 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@theholocron/cli@2.0.0-alpha.27':
-    resolution: {integrity: sha512-SDkX1FO+ocngUu7ez52KL5oqj9c4xQrRSIy7Q7hN4ncliySyiNEnNqnQOxMMPQQdOIiE86pjZWZMW/1Vb+uweg==}
+  '@theholocron/cli@2.0.0-alpha.34':
+    resolution: {integrity: sha512-Th9NnOKogK5IcNKhd2UNgcMvWpt243ePrzIE0zfwR+rBo9r9E3qWZp51Zxy21XnH0GpQI3GLWsM6vLla0y5z+A==}
     hasBin: true
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.27':
-    resolution: {integrity: sha512-0t+ApM2dhwZMlohTrxXEDUUXjojnbsKUxEU0qv1oXoykwV4jSLcXusd9KPJezt1pYDIawhfFP7KoAUmzVrgEbw==}
+  '@theholocron/holocron-plugin-github@2.0.0-alpha.34':
+    resolution: {integrity: sha512-e1iRygwO4UUyJGN5KyrlGl5rJGTcxBzxnT8M/3+Z7RIB3Mdaphuu9qjtgKpbqMsLzQCFEpcPjlx8VfkTM6TL8A==}
     peerDependencies:
-      '@theholocron/cli': 2.0.0-alpha.27
+      '@theholocron/cli': 2.0.0-alpha.34
 
   '@theholocron/http-client@0.1.0':
     resolution: {integrity: sha512-ul45D9F1nQmfbQ5x6Q4zQT20mBnmCZ7HmpSpXWvQPAf0kI8pZfd7rvpuc2fkXBI7w5uDfH+KFoaCGpzL+HDyoA==}
@@ -9316,16 +9316,16 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@theholocron/cli@2.0.0-alpha.27':
+  '@theholocron/cli@2.0.0-alpha.34':
     dependencies:
       '@napi-rs/keyring': 1.3.0
       '@theholocron/http-client': 0.1.0
       tsx: 4.23.1
       yargs: 18.0.0
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.27(@theholocron/cli@2.0.0-alpha.27)':
+  '@theholocron/holocron-plugin-github@2.0.0-alpha.34(@theholocron/cli@2.0.0-alpha.34)':
     dependencies:
-      '@theholocron/cli': 2.0.0-alpha.27
+      '@theholocron/cli': 2.0.0-alpha.34
       libsodium-wrappers: 0.7.16
 
   '@theholocron/http-client@0.1.0': {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,5 +4,5 @@ packages:
 # Holocron CLI and plugins — pinned in lockstep; bump together when running setup.
 catalogs:
   holocron:
-    '@theholocron/cli': 2.0.0-alpha.27
-    '@theholocron/holocron-plugin-github': 2.0.0-alpha.27
+    '@theholocron/cli': 2.0.0-alpha.34
+    '@theholocron/holocron-plugin-github': 2.0.0-alpha.34

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,5 +4,5 @@ packages:
 # Holocron CLI and plugins — pinned in lockstep; bump together when running setup.
 catalogs:
   holocron:
-    '@theholocron/cli': 2.0.0-alpha.34
-    '@theholocron/holocron-plugin-github': 2.0.0-alpha.34
+    '@theholocron/cli': 2.0.0-alpha.35
+    '@theholocron/holocron-plugin-github': 2.0.0-alpha.35


### PR DESCRIPTION
## Summary

- Bumps `@theholocron/cli` + `@theholocron/holocron-plugin-github` to `2.0.0-alpha.34`
- Writes `.editorconfig` — canonical settings including `indent_style = space` / `indent_size = 2` for `[*.md]`
- Writes `.editorconfig-checker.json` — excludes `LICENSE` files
- Syncs workflow caller version pins

## Test plan

- [ ] All CI checks pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->