### PR TITLE
chore(config): migrate to RepoConfig object and add HolocronConfig type

### DIFF
--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -1,13 +1,38 @@
 import { defineConfig } from "@theholocron/cli";
+import type { HolocronConfig } from "@theholocron/cli";
 
 export default defineConfig({
 	project: {
 		name: "configs",
 		description:
 			"Shared configuration packages for the theholocron organization.",
-		repo: "theholocron/configs",
-		repoPolicy: {
-			preset: "strict",
+		repo: {
+			name: "theholocron/configs",
+			protection: "strict",
+			topics: [
+				"browserslist-config",
+				"bundlewatch-config",
+				"commitlint-config",
+				"developer-tools",
+				"eslint-config",
+				"lint-staged-config",
+				"nodejs",
+				"prettier-config",
+				"semantic-release-config",
+				"shareable-configs",
+				"storybook-config",
+				"stylelint-config",
+				"tsconfig",
+				"tsdown-config",
+				"vite-config",
+				"vitest-config",
+			],
+			properties: {
+				lifecycle: "active",
+				open_source: true,
+				runtime_environment: "node",
+				uses_external_packages: true,
+			},
 		},
 		workflows: [
 			"lint",
@@ -33,4 +58,4 @@ export default defineConfig({
 			},
 		],
 	},
-});
+} satisfies HolocronConfig);


### PR DESCRIPTION
## Summary

- Migrates `project.repo` from a bare string to the `RepoConfig` object form with `protection`, `topics`, and `properties`
- Drops `project.repoPolicy` (removed from the schema in theholocron/holocron#146)
- Adds `import type { HolocronConfig }` and `satisfies HolocronConfig` for explicit in-file typing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->