### PR TITLE
chore: remove npm version badges from package table

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@ Shareable configuration used accross the Galaxy.
 
 ## Packages
 
-| Package                                                              | Version                                                                                                                                 | Description                                        |
-| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| [`@theholocron/browserslist-config`](./packages/browserslist-config) | [![npm](https://img.shields.io/npm/v/@theholocron/browserslist-config)](https://www.npmjs.com/package/@theholocron/browserslist-config) | Browser and device targets                         |
-| [`@theholocron/bundlewatch-config`](./packages/bundlewatch-config)   | [![npm](https://img.shields.io/npm/v/@theholocron/bundlewatch-config)](https://www.npmjs.com/package/@theholocron/bundlewatch-config)   | Bundle size monitoring                             |
-| [`@theholocron/commitlint-config`](./packages/commitlint-config)     | [![npm](https://img.shields.io/npm/v/@theholocron/commitlint-config)](https://www.npmjs.com/package/@theholocron/commitlint-config)     | Conventional commit enforcement                    |
-| [`@theholocron/eslint-config`](./packages/eslint-config)             | [![npm](https://img.shields.io/npm/v/@theholocron/eslint-config)](https://www.npmjs.com/package/@theholocron/eslint-config)             | ESLint rules for JS/TS/React/Next/Node             |
-| [`@theholocron/lint-staged-config`](./packages/lint-staged-config)   | [![npm](https://img.shields.io/npm/v/@theholocron/lint-staged-config)](https://www.npmjs.com/package/@theholocron/lint-staged-config)   | Pre-commit lint-staged hooks                       |
-| [`@theholocron/prettier-config`](./packages/prettier-config)         | [![npm](https://img.shields.io/npm/v/@theholocron/prettier-config)](https://www.npmjs.com/package/@theholocron/prettier-config)         | Prettier formatting rules                          |
-| [`@theholocron/storybook-config`](./packages/storybook-config)       | [![npm](https://img.shields.io/npm/v/@theholocron/storybook-config)](https://www.npmjs.com/package/@theholocron/storybook-config)       | Storybook addon and theme setup                    |
-| [`@theholocron/stylelint-config`](./packages/stylelint-config)       | [![npm](https://img.shields.io/npm/v/@theholocron/stylelint-config)](https://www.npmjs.com/package/@theholocron/stylelint-config)       | StyleLint rules for CSS/SCSS                       |
-| [`@theholocron/tsconfig`](./packages/tsconfig)                       | [![npm](https://img.shields.io/npm/v/@theholocron/tsconfig)](https://www.npmjs.com/package/@theholocron/tsconfig)                       | TypeScript base configs (NextJS, node-lts)         |
-| [`@theholocron/vite-config`](./packages/vite-config)                 | [![npm](https://img.shields.io/npm/v/@theholocron/vite-config)](https://www.npmjs.com/package/@theholocron/vite-config)                 | Vite presets for libraries, React apps, Node tools |
-| [`@theholocron/vitest-config`](./packages/vitest-config)             | [![npm](https://img.shields.io/npm/v/@theholocron/vitest-config)](https://www.npmjs.com/package/@theholocron/vitest-config)             | Vitest presets and coverage bundles                |
-| [`@theholocron/jest-config`](./packages/jest-config)                 | [![npm](https://img.shields.io/npm/v/@theholocron/jest-config)](https://www.npmjs.com/package/@theholocron/jest-config)                 | **Deprecated** — use `@theholocron/vitest-config`  |
+| Package                                                              | Description                                        |
+| -------------------------------------------------------------------- | -------------------------------------------------- |
+| [`@theholocron/browserslist-config`](./packages/browserslist-config) | Browser and device targets                         |
+| [`@theholocron/bundlewatch-config`](./packages/bundlewatch-config)   | Bundle size monitoring                             |
+| [`@theholocron/commitlint-config`](./packages/commitlint-config)     | Conventional commit enforcement                    |
+| [`@theholocron/eslint-config`](./packages/eslint-config)             | ESLint rules for JS/TS/React/Next/Node             |
+| [`@theholocron/lint-staged-config`](./packages/lint-staged-config)   | Pre-commit lint-staged hooks                       |
+| [`@theholocron/prettier-config`](./packages/prettier-config)         | Prettier formatting rules                          |
+| [`@theholocron/storybook-config`](./packages/storybook-config)       | Storybook addon and theme setup                    |
+| [`@theholocron/stylelint-config`](./packages/stylelint-config)       | StyleLint rules for CSS/SCSS                       |
+| [`@theholocron/tsconfig`](./packages/tsconfig)                       | TypeScript base configs (NextJS, node-lts)         |
+| [`@theholocron/vite-config`](./packages/vite-config)                 | Vite presets for libraries, React apps, Node tools |
+| [`@theholocron/vitest-config`](./packages/vitest-config)             | Vitest presets and coverage bundles                |
+| [`@theholocron/jest-config`](./packages/jest-config)                 | **Deprecated** — use `@theholocron/vitest-config`  |
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Removes the `Version` column and npm shields badges from the package table in `README.md`
- Badges drift between releases and duplicate what GitHub's releases page already shows
- Lockstep versioning means all packages share one version anyway — a per-package badge adds no information

## Test plan

- [x] Table renders correctly with just Package and Description columns
- [x] No broken links
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->