### PR TITLE
fix(commitlint-config): disable body-max-line-length to avoid trailer false positives

### DIFF
--- a/packages/commitlint-config/commitlint.config.js
+++ b/packages/commitlint-config/commitlint.config.js
@@ -5,6 +5,12 @@
 const config = {
 	extends: ["@commitlint/config-conventional"],
 	ignores: [(message) => /^chore\(deps(-dev)?\): Bump/.test(message)],
+	rules: {
+		// Trailers (Co-authored-by, Signed-off-by) are parsed as body text when
+		// there is no body paragraph, causing false positives. header-max-length
+		// covers the only line length that actually matters for readability.
+		"body-max-line-length": [0, "always", Infinity],
+	},
 };
 
 export default config;


### PR DESCRIPTION
Trailers like `Co-authored-by:` and `Signed-off-by:` are parsed as body text by commitlint when there is no actual body paragraph between the subject and the trailers. This causes false positives on the `body-max-line-length` rule for commits with long bot/user email addresses. Disables the rule — `header-max-length` covers the only line length that actually matters for readability.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->