### PR TITLE
chore: package metadata audit — keywords, engines, typecheck, homepage fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build": "turbo run build",
     "lint": "turbo run lint",
     "prepare": "turbo run build",
-    "test": "turbo run test"
+    "test": "turbo run test",
+    "typecheck": "turbo run typecheck"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.2.1",

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -10,11 +10,20 @@
   },
   "license": "GPL-3.0",
   "author": "Newton Koumantzelis",
+  "keywords": [
+    "browserslist",
+    "browsers",
+    "config",
+    "theholocron"
+  ],
   "main": "index.js",
   "files": [
     "browserslistrc.json",
     "index.js"
   ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bundlewatch-config/package.json
+++ b/packages/bundlewatch-config/package.json
@@ -10,10 +10,18 @@
   },
   "license": "GPL-3.0",
   "author": "Newton Koumantzelis",
+  "keywords": [
+    "bundlewatch",
+    "bundle-size",
+    "performance",
+    "config",
+    "theholocron"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",
@@ -33,6 +41,9 @@
   ],
   "peerDependencies": {
     "bundlewatch": "^0.4.0"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -10,11 +10,20 @@
   },
   "license": "GPL-3.0",
   "author": "Newton Koumantzelis",
+  "keywords": [
+    "commitlint",
+    "conventional-commits",
+    "git",
+    "commits",
+    "config",
+    "theholocron"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsdown",
-    "test": "commitlint --from HEAD~1 --to HEAD --verbose"
+    "test": "commitlint --from HEAD~1 --to HEAD --verbose",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@commitlint/types": "^21.2.0",
@@ -36,6 +45,9 @@
   "peerDependencies": {
     "@commitlint/cli": "^21",
     "@commitlint/config-conventional": "^21"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -22,7 +22,8 @@
   ],
   "type": "module",
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",
@@ -131,6 +132,9 @@
     "eslint-plugin-storybook": {
       "optional": true
     }
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -3,7 +3,7 @@
   "version": "7.0.0",
   "description": "DEPRECATED: Use @theholocron/vitest-config instead.",
   "deprecated": "This package is no longer maintained. Migrate to @theholocron/vitest-config.",
-  "homepage": "https://github.com/theholocron/configs/tree/main/packages/jest-preset#readme",
+  "homepage": "https://github.com/theholocron/configs/tree/main/packages/jest-config#readme",
   "bugs": "https://github.com/theholocron/configs/issues",
   "repository": {
     "type": "git",
@@ -11,10 +11,18 @@
   },
   "license": "GPL-3.0",
   "author": "Newton Koumantzelis",
+  "keywords": [
+    "jest",
+    "testing",
+    "deprecated",
+    "config",
+    "theholocron"
+  ],
   "type": "module",
   "main": "dist/jest-preset.js",
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",
@@ -44,6 +52,9 @@
     "cypress": "^14",
     "jest": "^29",
     "jsdom": "^26"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/lint-staged-config/package.json
+++ b/packages/lint-staged-config/package.json
@@ -10,11 +10,20 @@
   },
   "license": "GPL-3.0",
   "author": "Newton Koumantzelis",
+  "keywords": [
+    "lint-staged",
+    "husky",
+    "git-hooks",
+    "pre-commit",
+    "config",
+    "theholocron"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsdown",
-    "prepare": "husky"
+    "prepare": "husky",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",
@@ -46,6 +55,9 @@
     "sort-package-json": {
       "optional": true
     }
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -10,10 +10,18 @@
   },
   "license": "GPL-3.0",
   "author": "Newton Koumantzelis",
+  "keywords": [
+    "prettier",
+    "formatting",
+    "code-style",
+    "config",
+    "theholocron"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",
@@ -33,6 +41,9 @@
   ],
   "peerDependencies": {
     "prettier": "^3"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/semantic-release-config/package.json
+++ b/packages/semantic-release-config/package.json
@@ -10,9 +10,18 @@
   },
   "license": "GPL-3.0",
   "author": "Newton Koumantzelis",
+  "keywords": [
+    "semantic-release",
+    "release",
+    "versioning",
+    "changelog",
+    "config",
+    "theholocron"
+  ],
   "type": "module",
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",
@@ -44,6 +53,9 @@
     "@semantic-release/exec": {
       "optional": true
     }
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -10,10 +10,19 @@
   },
   "license": "GPL-3.0",
   "author": "Newton Koumantzelis",
+  "keywords": [
+    "storybook",
+    "components",
+    "react",
+    "visual-testing",
+    "config",
+    "theholocron"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",
@@ -64,6 +73,9 @@
     "react": "^19",
     "react-dom": "^19",
     "storybook-addon-pseudo-states": "^9"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -2,7 +2,7 @@
   "name": "@theholocron/stylelint-config",
   "version": "7.0.0",
   "description": "A StyleLint configuration for writing well-formed CSS within the Galaxy.",
-  "homepage": "https://github.com/theholocron/configs/tree/main/packages/lint-staged-config#readme",
+  "homepage": "https://github.com/theholocron/configs/tree/main/packages/stylelint-config#readme",
   "bugs": "https://github.com/theholocron/configs/issues",
   "repository": {
     "type": "git",
@@ -10,10 +10,19 @@
   },
   "license": "GPL-3.0",
   "author": "Newton Koumantzelis",
+  "keywords": [
+    "stylelint",
+    "css",
+    "scss",
+    "linting",
+    "config",
+    "theholocron"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",
@@ -35,6 +44,9 @@
     "stylelint": "^16",
     "stylelint-config-standard": "^38",
     "stylelint-config-standard-scss": "^15"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -10,6 +10,12 @@
   },
   "license": "GPL-3.0",
   "author": "Newton Koumantzelis",
+  "keywords": [
+    "typescript",
+    "tsconfig",
+    "config",
+    "theholocron"
+  ],
   "exports": {
     "./nextjs": "./nextjs/tsconfig.json",
     "./node-lts": "./node-lts/tsconfig.json"
@@ -20,6 +26,9 @@
   ],
   "peerDependencies": {
     "typescript": "^5"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tsdown-config/package.json
+++ b/packages/tsdown-config/package.json
@@ -10,9 +10,18 @@
   },
   "license": "GPL-3.0",
   "author": "Newton Koumantzelis",
+  "keywords": [
+    "tsdown",
+    "build",
+    "bundler",
+    "typescript",
+    "config",
+    "theholocron"
+  ],
   "type": "module",
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",
@@ -36,6 +45,9 @@
   ],
   "peerDependencies": {
     "tsdown": "^0"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vite-config/package.json
+++ b/packages/vite-config/package.json
@@ -10,9 +10,18 @@
   },
   "license": "GPL-3.0",
   "author": "Newton Koumantzelis",
+  "keywords": [
+    "vite",
+    "bundler",
+    "react",
+    "build",
+    "config",
+    "theholocron"
+  ],
   "type": "module",
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",
@@ -61,6 +70,9 @@
     "vite-tsconfig-paths": {
       "optional": true
     }
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vitest-config/package.json
+++ b/packages/vitest-config/package.json
@@ -10,9 +10,18 @@
   },
   "license": "GPL-3.0",
   "author": "Newton Koumantzelis",
+  "keywords": [
+    "vitest",
+    "testing",
+    "coverage",
+    "typescript",
+    "config",
+    "theholocron"
+  ],
   "type": "module",
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",
@@ -87,6 +96,9 @@
     "playwright": {
       "optional": true
     }
+  },
+  "engines": {
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,7 @@
   "tasks": {
     "build": { "outputs": ["dist/**"] },
     "lint": { "dependsOn": ["^build"] },
-    "test": { "dependsOn": ["build", "^build"] }
+    "test": { "dependsOn": ["build", "^build"] },
+    "typecheck": { "dependsOn": ["^build"] }
   }
 }


### PR DESCRIPTION
## Summary

- **Fixes #246** — `jest-config` homepage pointed to `packages/jest-preset` (404); corrected to `packages/jest-config`
- **Fixes #247** — `stylelint-config` homepage pointed to `packages/lint-staged-config` (wrong package); corrected
- **Fixes #248** — Added `keywords` array to all 13 packages that were missing one (only `eslint-config` had keywords before); aids npm discoverability
- **Fixes #249** — Added `"engines": { "node": ">=22.0.0" }` to all 14 packages so consumers on older Node get a clear warning at install time
- **Fixes #251** — Added `"typecheck": "tsc --noEmit"` script to all 12 TypeScript packages, wired the `typecheck` task in `turbo.json`, and added `"typecheck": "turbo run typecheck"` to the root `package.json`; `browserslist-config` (plain JS) and `tsconfig` (JSON only) are intentionally excluded

## Test plan

- [x] `pnpm build` — all 12 packages built successfully, no new errors
- [ ] `pnpm typecheck` — verify locally with `pnpm install && pnpm typecheck`
- [ ] Confirm jest-config and stylelint-config homepage links resolve correctly on npm after release
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->