### PR TITLE
docs: readme and CLAUDE.md audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,11 +28,12 @@ packages/
   jest-config/           — @theholocron/jest-config     (DEPRECATED → vitest-config)
   lint-staged-config/    — @theholocron/lint-staged-config
   prettier-config/       — @theholocron/prettier-config
+  semantic-release-config/ — @theholocron/semantic-release-config
   storybook-config/      — @theholocron/storybook-config
   stylelint-config/      — @theholocron/stylelint-config
   tsconfig/              — @theholocron/tsconfig         (nextjs/ node-lts/)
+  tsdown-config/         — @theholocron/tsdown-config    (presets/)
   vite-config/           — @theholocron/vite-config      (presets/)
-  semantic-release-config/ — @theholocron/semantic-release-config
   vitest-config/         — @theholocron/vitest-config    (presets/ + bundles/)
 scripts/
   bump-versions.mjs      — lockstep version bump (called by semantic-release)
@@ -44,14 +45,22 @@ release.config.ts        — semantic-release config (lockstep publish, root CHA
 Use the `.claude/skills/configs-package.md` skill, which scaffolds the full
 package. Quick checklist:
 
-1. Create `packages/<tool>-config/` with:
-   - `package.json` — follow the shape of an existing package; include all
-     relevant `peerDependencies` as optional where the tool itself is optional
-   - `index.js` — default export or named export(s) of the config object
+1. Create `packages/<tool>-config/` with the following files, modelled on an
+   existing TypeScript package (e.g. `prettier-config`):
+   - `package.json` — follow the standard shape; include all relevant
+     `peerDependencies`, mark optional ones under `peerDependenciesMeta`
+   - `index.ts` — default export or named export(s) of the config object/function
+   - `tsconfig.json` — extend `@theholocron/tsconfig/node-lts`; set
+     `rootDir: "."` and `outDir: "dist"`
+   - `tsdown.config.ts` — list every entry point that needs its own dist file
+   - `vitest.config.ts` — use the `node` preset from `@theholocron/vitest-config`
+   - `index.test.ts` — smoke test that every export has the expected runtime shape
    - `README.md` — Installation + Usage sections; see existing packages for tone
-2. Add the package to `pnpm-workspace.yaml` if it is not auto-discovered.
-3. Verify `pnpm install` resolves and `pnpm lint` passes (ESLint config lints itself).
-4. Open a PR with a `feat:` commit — semantic-release will compute a minor bump
+2. Add `vitest` and `@theholocron/vitest-config: "workspace:*"` to `devDependencies`.
+3. Add `"build": "tsdown"`, `"test": "vitest run"`, and `"typecheck": "tsc --noEmit"`
+   to `scripts`.
+4. Verify `pnpm install` resolves, `pnpm build` succeeds, and `pnpm test` passes.
+5. Open a PR with a `feat:` commit — semantic-release will compute a minor bump
    and publish all packages in lockstep.
 
 ## Code patterns
@@ -76,9 +85,12 @@ package. Quick checklist:
 
 ## Quality
 
+- `pnpm build` — compiles all TypeScript packages to `dist/` via tsdown.
+- `pnpm test` — vitest smoke tests across all packages via Turbo. Each package
+  has an `index.test.ts` (or similar) that verifies every export has the correct
+  runtime shape. Tests run after build (`^build` dependency in turbo.json).
+- `pnpm typecheck` — `tsc --noEmit` in each TypeScript package.
 - `pnpm lint` — ESLint via Turbo across all packages. Must pass before commit.
-- No test suite (config packages have no logic to unit-test; rely on consumer
-  repos for integration validation).
 - `pnpm install --frozen-lockfile` must succeed after any `package.json` change.
 
 ## Releases (automated)

--- a/README.md
+++ b/README.md
@@ -6,18 +6,20 @@ Shareable configuration used accross the Galaxy.
 
 | Package                                                              | Description                                        |
 | -------------------------------------------------------------------- | -------------------------------------------------- |
-| [`@theholocron/browserslist-config`](./packages/browserslist-config) | Browser and device targets                         |
-| [`@theholocron/bundlewatch-config`](./packages/bundlewatch-config)   | Bundle size monitoring                             |
-| [`@theholocron/commitlint-config`](./packages/commitlint-config)     | Conventional commit enforcement                    |
-| [`@theholocron/eslint-config`](./packages/eslint-config)             | ESLint rules for JS/TS/React/Next/Node             |
-| [`@theholocron/lint-staged-config`](./packages/lint-staged-config)   | Pre-commit lint-staged hooks                       |
-| [`@theholocron/prettier-config`](./packages/prettier-config)         | Prettier formatting rules                          |
-| [`@theholocron/storybook-config`](./packages/storybook-config)       | Storybook addon and theme setup                    |
-| [`@theholocron/stylelint-config`](./packages/stylelint-config)       | StyleLint rules for CSS/SCSS                       |
-| [`@theholocron/tsconfig`](./packages/tsconfig)                       | TypeScript base configs (NextJS, node-lts)         |
-| [`@theholocron/vite-config`](./packages/vite-config)                 | Vite presets for libraries, React apps, Node tools |
-| [`@theholocron/vitest-config`](./packages/vitest-config)             | Vitest presets and coverage bundles                |
-| [`@theholocron/jest-config`](./packages/jest-config)                 | **Deprecated** — use `@theholocron/vitest-config`  |
+| [`@theholocron/browserslist-config`](./packages/browserslist-config)         | Browser and device targets                         |
+| [`@theholocron/bundlewatch-config`](./packages/bundlewatch-config)           | Bundle size monitoring                             |
+| [`@theholocron/commitlint-config`](./packages/commitlint-config)             | Conventional commit enforcement                    |
+| [`@theholocron/eslint-config`](./packages/eslint-config)                     | ESLint rules for JS/TS/React/Next/Node             |
+| [`@theholocron/lint-staged-config`](./packages/lint-staged-config)           | Pre-commit lint-staged hooks                       |
+| [`@theholocron/prettier-config`](./packages/prettier-config)                 | Prettier formatting rules                          |
+| [`@theholocron/semantic-release-config`](./packages/semantic-release-config) | Semantic-release config for automated versioning   |
+| [`@theholocron/storybook-config`](./packages/storybook-config)               | Storybook addon and theme setup                    |
+| [`@theholocron/stylelint-config`](./packages/stylelint-config)               | StyleLint rules for CSS/SCSS                       |
+| [`@theholocron/tsconfig`](./packages/tsconfig)                               | TypeScript base configs (NextJS, node-lts)         |
+| [`@theholocron/tsdown-config`](./packages/tsdown-config)                     | tsdown presets for ESM library builds              |
+| [`@theholocron/vite-config`](./packages/vite-config)                         | Vite presets for libraries, React apps, Node tools |
+| [`@theholocron/vitest-config`](./packages/vitest-config)                     | Vitest presets and coverage bundles                |
+| [`@theholocron/jest-config`](./packages/jest-config)                         | **Deprecated** — use `@theholocron/vitest-config`  |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Shareable configuration used accross the Galaxy.
 
 ## Packages
 
-| Package                                                              | Description                                        |
-| -------------------------------------------------------------------- | -------------------------------------------------- |
+| Package                                                                      | Description                                        |
+| ---------------------------------------------------------------------------- | -------------------------------------------------- |
 | [`@theholocron/browserslist-config`](./packages/browserslist-config)         | Browser and device targets                         |
 | [`@theholocron/bundlewatch-config`](./packages/bundlewatch-config)           | Bundle size monitoring                             |
 | [`@theholocron/commitlint-config`](./packages/commitlint-config)             | Conventional commit enforcement                    |

--- a/packages/bundlewatch-config/README.md
+++ b/packages/bundlewatch-config/README.md
@@ -10,18 +10,24 @@ npm install --save-dev @theholocron/bundlewatch-config bundlewatch
 
 ## Usage
 
-Add the following script to your project `package.json`:
+Create a `bundlewatch.config.js` at your project root that re-exports the shared config:
+
+```js
+export { default } from "@theholocron/bundlewatch-config";
+```
+
+Then add a script to `package.json`:
 
 ```json
 {
   "scripts": {
-    "audit:bundle": "bundlewatch --config ./node_modules/@theholocron/bundlewatch-config/bundlewatch.config.js"
+    "audit:bundle": "bundlewatch --config bundlewatch.config.js"
   }
 }
 ```
 
-Then run:
+Run it with:
 
 ```bash
-npm run audit:bundle
+pnpm run audit:bundle
 ```

--- a/packages/lint-staged-config/README.md
+++ b/packages/lint-staged-config/README.md
@@ -21,25 +21,23 @@ npx husky init
 Replace the contents of `.husky/pre-commit` with:
 
 ```bash
-pnpm exec lint-staged --config node_modules/@theholocron/lint-staged-config/lint-staged.config.js
+pnpm exec lint-staged
 ```
 
-Or add it to `package.json`:
+Then create a `lint-staged.config.js` at your project root:
 
-```json
-{
-  "lint-staged": "node_modules/@theholocron/lint-staged-config/lint-staged.config.js"
-}
+```js
+export { default } from "@theholocron/lint-staged-config";
 ```
 
 ## What runs on staged files
 
-| File pattern               | Commands                                           |
-| -------------------------- | -------------------------------------------------- |
-| `*.{js,jsx}`               | `prettier --write`, `eslint`                       |
-| `*.{ts,tsx}`               | `prettier --write`, `eslint`, `tsc-files --noEmit` |
-| `*.css`                    | `stylelint --fix`                                  |
-| `*.scss`                   | `stylelint --syntax=scss --fix`                    |
-| `*.{md,mdx}`               | `prettier --write`                                 |
-| `*.{png,jpeg,jpg,gif,svg}` | `imagemin-lint-staged`                             |
-| `package.json`             | `sort-package-json`                                |
+| File pattern               | Commands                       |
+| -------------------------- | ------------------------------ |
+| `*.{js,jsx}`               | `prettier --write`, `eslint`   |
+| `*.{ts,tsx}`               | `prettier --write`, `eslint`   |
+| `*.css`                    | `stylelint --fix`              |
+| `*.scss`                   | `stylelint --syntax=scss --fix`|
+| `*.{md,mdx}`               | `prettier --write`             |
+| `*.{png,jpeg,jpg,gif,svg}` | `imagemin-lint-staged`         |
+| `package.json`             | `sort-package-json`            |

--- a/packages/lint-staged-config/README.md
+++ b/packages/lint-staged-config/README.md
@@ -32,12 +32,12 @@ export { default } from "@theholocron/lint-staged-config";
 
 ## What runs on staged files
 
-| File pattern               | Commands                       |
-| -------------------------- | ------------------------------ |
-| `*.{js,jsx}`               | `prettier --write`, `eslint`   |
-| `*.{ts,tsx}`               | `prettier --write`, `eslint`   |
-| `*.css`                    | `stylelint --fix`              |
-| `*.scss`                   | `stylelint --syntax=scss --fix`|
-| `*.{md,mdx}`               | `prettier --write`             |
-| `*.{png,jpeg,jpg,gif,svg}` | `imagemin-lint-staged`         |
-| `package.json`             | `sort-package-json`            |
+| File pattern               | Commands                        |
+| -------------------------- | ------------------------------- |
+| `*.{js,jsx}`               | `prettier --write`, `eslint`    |
+| `*.{ts,tsx}`               | `prettier --write`, `eslint`    |
+| `*.css`                    | `stylelint --fix`               |
+| `*.scss`                   | `stylelint --syntax=scss --fix` |
+| `*.{md,mdx}`               | `prettier --write`              |
+| `*.{png,jpeg,jpg,gif,svg}` | `imagemin-lint-staged`          |
+| `package.json`             | `sort-package-json`             |

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -15,5 +15,5 @@ In your project `stylelint.config.js`:
 ```javascript
 import theHolocron from "@theholocron/stylelint-config";
 
-export default [...theHolocron];
+export default theHolocron;
 ```


### PR DESCRIPTION
## Summary

Fixes documentation rot across the root README, CLAUDE.md, and three package READMEs.

### Root README

Added the two missing packages — `semantic-release-config` and `tsdown-config` — to the packages table. 14 packages exist; only 12 were listed.

### CLAUDE.md

- **Repo layout**: added `tsdown-config` (was absent from the layout block)
- **Adding a new config package**: rewrote the checklist to reflect the TypeScript build setup that landed in #242. The old instructions described `index.js`; the current pattern is `index.ts` + `tsconfig.json` + `tsdown.config.ts` + `vitest.config.ts` + a smoke test file
- **Quality**: removed the stale "No test suite" line (smoke tests now exist per #253); documented all four quality commands (`build`, `test`, `typecheck`, `lint`) in order

### Package README correctness fixes

| Package | Bug | Fix |
|---------|-----|-----|
| `bundlewatch-config` | Usage pointed to `bundlewatch.config.js` which no longer exists (file was renamed to `index.ts` in #242) | Show a root-level re-export file pattern |
| `lint-staged-config` | Usage pointed to the old `lint-staged.config.js` path; table listed `tsc-files --noEmit` which was never in the actual config source | Fix path to re-export pattern; remove phantom command from table |
| `stylelint-config` | `export default [...theHolocron]` spreads a plain object — a runtime `TypeError` | Fix to `export default theHolocron` |

## Test plan

- [x] All 14 packages listed in root README
- [x] `stylelint-config` usage verified against actual export shape in `index.ts`
- [x] `lint-staged-config` table verified against actual config source
- [x] `bundlewatch-config` usage verified against bundlewatch CLI docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->