### PR TITLE
fix(bundlewatch-config): deprecate in favor of Codecov bundle analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Conventions for working on the `theholocron/configs` monorepo.
 ```
 packages/
   browserslist-config/   — @theholocron/browserslist-config
-  bundlewatch-config/    — @theholocron/bundlewatch-config
+  bundlewatch-config/    — @theholocron/bundlewatch-config  (DEPRECATED → Codecov bundle analysis via vite-config)
   commitlint-config/     — @theholocron/commitlint-config
   eslint-config/         — @theholocron/eslint-config  (configs/ + bundles/)
   lint-staged-config/    — @theholocron/lint-staged-config

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Shareable configuration used accross the Galaxy.
 | Package                                                                      | Description                                        |
 | ---------------------------------------------------------------------------- | -------------------------------------------------- |
 | [`@theholocron/browserslist-config`](./packages/browserslist-config)         | Browser and device targets                         |
-| [`@theholocron/bundlewatch-config`](./packages/bundlewatch-config)           | Bundle size monitoring                             |
+| [`@theholocron/bundlewatch-config`](./packages/bundlewatch-config)           | **Deprecated** — use Codecov bundle analysis via `@theholocron/vite-config` |
 | [`@theholocron/commitlint-config`](./packages/commitlint-config)             | Conventional commit enforcement                    |
 | [`@theholocron/eslint-config`](./packages/eslint-config)                     | ESLint rules for JS/TS/React/Next/Node             |
 | [`@theholocron/lint-staged-config`](./packages/lint-staged-config)           | Pre-commit lint-staged hooks                       |

--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@ Shareable configuration used accross the Galaxy.
 
 ## Packages
 
-| Package                                                                      | Description                                        |
-| ---------------------------------------------------------------------------- | -------------------------------------------------- |
-| [`@theholocron/browserslist-config`](./packages/browserslist-config)         | Browser and device targets                         |
+| Package                                                                      | Description                                                                 |
+| ---------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [`@theholocron/browserslist-config`](./packages/browserslist-config)         | Browser and device targets                                                  |
 | [`@theholocron/bundlewatch-config`](./packages/bundlewatch-config)           | **Deprecated** — use Codecov bundle analysis via `@theholocron/vite-config` |
-| [`@theholocron/commitlint-config`](./packages/commitlint-config)             | Conventional commit enforcement                    |
-| [`@theholocron/eslint-config`](./packages/eslint-config)                     | ESLint rules for JS/TS/React/Next/Node             |
-| [`@theholocron/lint-staged-config`](./packages/lint-staged-config)           | Pre-commit lint-staged hooks                       |
-| [`@theholocron/prettier-config`](./packages/prettier-config)                 | Prettier formatting rules                          |
-| [`@theholocron/semantic-release-config`](./packages/semantic-release-config) | Semantic-release config for automated versioning   |
-| [`@theholocron/storybook-config`](./packages/storybook-config)               | Storybook addon and theme setup                    |
-| [`@theholocron/stylelint-config`](./packages/stylelint-config)               | StyleLint rules for CSS/SCSS                       |
-| [`@theholocron/tsconfig`](./packages/tsconfig)                               | TypeScript base configs (NextJS, node-lts)         |
-| [`@theholocron/tsdown-config`](./packages/tsdown-config)                     | tsdown presets for ESM library builds              |
-| [`@theholocron/vite-config`](./packages/vite-config)                         | Vite presets for libraries, React apps, Node tools |
-| [`@theholocron/vitest-config`](./packages/vitest-config)                     | Vitest presets and coverage bundles                |
+| [`@theholocron/commitlint-config`](./packages/commitlint-config)             | Conventional commit enforcement                                             |
+| [`@theholocron/eslint-config`](./packages/eslint-config)                     | ESLint rules for JS/TS/React/Next/Node                                      |
+| [`@theholocron/lint-staged-config`](./packages/lint-staged-config)           | Pre-commit lint-staged hooks                                                |
+| [`@theholocron/prettier-config`](./packages/prettier-config)                 | Prettier formatting rules                                                   |
+| [`@theholocron/semantic-release-config`](./packages/semantic-release-config) | Semantic-release config for automated versioning                            |
+| [`@theholocron/storybook-config`](./packages/storybook-config)               | Storybook addon and theme setup                                             |
+| [`@theholocron/stylelint-config`](./packages/stylelint-config)               | StyleLint rules for CSS/SCSS                                                |
+| [`@theholocron/tsconfig`](./packages/tsconfig)                               | TypeScript base configs (NextJS, node-lts)                                  |
+| [`@theholocron/tsdown-config`](./packages/tsdown-config)                     | tsdown presets for ESM library builds                                       |
+| [`@theholocron/vite-config`](./packages/vite-config)                         | Vite presets for libraries, React apps, Node tools                          |
+| [`@theholocron/vitest-config`](./packages/vitest-config)                     | Vitest presets and coverage bundles                                         |
 
 ## Development
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -33,11 +33,6 @@ component_management:
       paths:
         - packages/browserslist-config/**
 
-    - component_id: bundlewatch-config
-      name: "bundlewatch-config"
-      paths:
-        - packages/bundlewatch-config/**
-
     - component_id: commitlint-config
       name: "commitlint-config"
       paths:

--- a/packages/bundlewatch-config/README.md
+++ b/packages/bundlewatch-config/README.md
@@ -1,22 +1,46 @@
-# Bundlewatch Config
+# Bundlewatch Config — Deprecated
 
-A [Bundlewatch configuration](https://bundlewatch.io/#/reference/configuration) for monitoring bundle size in libraries.
+> **This package is deprecated.** New projects should use Codecov bundle analysis
+> via [`@theholocron/vite-config`](../vite-config) instead, which uploads bundle
+> stats to Codecov automatically with no additional configuration.
 
-## Installation
+## Migration
+
+Install the peer dependency:
+
+```bash
+pnpm add -D @codecov/vite-plugin
+```
+
+All three `@theholocron/vite-config` presets (`library`, `reactApp`, `nodeApp`) automatically
+include `@codecov/vite-plugin` when it is installed and `CODECOV_TOKEN` is set in the
+environment — no changes to your `vite.config.ts` are needed.
+
+Add the following to your `codecov.yml` to control when Codecov posts bundle size comments on PRs:
+
+```yaml
+comment:
+  require_bundle_changes: true
+  bundle_change_threshold: "1Kb"
+```
+
+See the [`@theholocron/vite-config` README](../vite-config/README.md) for full setup details.
+
+## Legacy Installation
 
 ```bash
 npm install --save-dev @theholocron/bundlewatch-config bundlewatch
 ```
 
-## Usage
+## Legacy Usage
 
-Create a `bundlewatch.config.js` at your project root that re-exports the shared config:
+Create a `bundlewatch.config.js` at your project root:
 
 ```js
 export { default } from "@theholocron/bundlewatch-config";
 ```
 
-Then add a script to `package.json`:
+Add a script to `package.json`:
 
 ```json
 {
@@ -24,10 +48,4 @@ Then add a script to `package.json`:
     "audit:bundle": "bundlewatch --config bundlewatch.config.js"
   }
 }
-```
-
-Run it with:
-
-```bash
-pnpm run audit:bundle
 ```

--- a/packages/bundlewatch-config/package.json
+++ b/packages/bundlewatch-config/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@theholocron/bundlewatch-config",
   "version": "7.1.1",
-  "description": "A Bundlewatch configuration for monitoring the file size of libraries in the Galaxy.",
+  "description": "DEPRECATED: Use Codecov bundle analysis via @theholocron/vite-config instead.",
+  "deprecated": "This package is no longer maintained. Migrate to Codecov bundle analysis — install @codecov/vite-plugin and use any @theholocron/vite-config preset. Bundle stats upload automatically when CODECOV_TOKEN is set.",
   "homepage": "https://github.com/theholocron/configs/tree/main/packages/bundlewatch-config#readme",
   "bugs": "https://github.com/theholocron/configs/issues",
   "repository": {


### PR DESCRIPTION
## Summary

Deprecates `@theholocron/bundlewatch-config` in favour of Codecov bundle analysis via `@theholocron/vite-config`.

## Why

`bundlewatch@0.4.x` is stuck on `axios@0.31.1` — the latest bundlewatch release and there are no plans from upstream to update it. All of its functionality (bundle size monitoring per CI run, PR comments on size changes) is fully covered by `@codecov/vite-plugin`, which is already baked into all three `@theholocron/vite-config` presets (`library`, `reactApp`, `nodeApp`) and activates automatically when `CODECOV_TOKEN` is set.

## Changes

- `package.json` — `deprecated` field added, description updated
- `README.md` — rewritten as a deprecation notice with migration steps (install `@codecov/vite-plugin`, add `require_bundle_changes` to `codecov.yml`)
- Root `README.md` — marked deprecated in the packages table
- `codecov.yml` — removed from components (12 components now, consistent with the deprecated-packages-excluded policy set by jest-config removal)
- `CLAUDE.md` — repo layout entry updated to note deprecation

The package stays on npm and continues to receive lockstep version bumps — nothing breaks for existing consumers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->