### PR TITLE
fix: override uuid to ^11.1.1 (CVE — missing buffer bounds check)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "pnpm": {
     "overrides": {
       "@commitlint/config-conventional>conventional-changelog-conventionalcommits": "7",
-      "yuku-parser": "0.6.3"
+      "yuku-parser": "0.6.3",
+      "uuid": "^11.1.1"
     }
   },
   "packageManager": "pnpm@10.34.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ catalogs:
 overrides:
   '@commitlint/config-conventional>conventional-changelog-conventionalcommits': '7'
   yuku-parser: 0.6.3
+  uuid: ^11.1.1
 
 importers:
 
@@ -6110,9 +6111,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -10344,7 +10344,7 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       p-map: 3.0.0
       rimraf: 3.0.2
-      uuid: 8.3.2
+      uuid: 11.1.1
 
   istanbul-lib-report@3.0.1:
     dependencies:
@@ -10513,7 +10513,7 @@ snapshots:
     dependencies:
       mkdirp: 1.0.4
       strip-ansi: 6.0.1
-      uuid: 8.3.2
+      uuid: 11.1.1
       xml: 1.0.1
 
   jest-leak-detector@29.7.0:
@@ -10557,7 +10557,7 @@ snapshots:
       nyc: 15.1.0
       playwright-core: 1.61.1
       rimraf: 3.0.2
-      uuid: 8.3.2
+      uuid: 11.1.1
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -12538,7 +12538,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@8.3.2: {}
+  uuid@11.1.1: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:


### PR DESCRIPTION
Closes Dependabot alert #151.

## Problem

`uuid@8.3.2` was pulled in transitively via `@storybook/test-runner → jest-haste-map`. The CVE (missing buffer bounds check in v3/v5/v6 when `buf` is provided) has no patch below v11.1.1.

## Fix

Add a `pnpm.overrides` entry to force all uuid resolutions to `^11.1.1`:

```json
"pnpm": {
  "overrides": {
    "uuid": "^11.1.1"
  }
}
```

uuid v11 explicitly supports CommonJS (the lockfile's own deprecation notice confirms this: *"For CommonJS codebases, use uuid@11"*), so forcing jest-haste-map onto it is safe. All 48 tests pass with uuid@11.1.1.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->