### PR TITLE
feat: add @theholocron/holocron-config with shareable presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Shareable configuration used accross the Galaxy.
 | [`@theholocron/browserslist-config`](./packages/browserslist-config)         | Browser and device targets                         |
 | [`@theholocron/commitlint-config`](./packages/commitlint-config)             | Conventional commit enforcement                    |
 | [`@theholocron/eslint-config`](./packages/eslint-config)                     | ESLint rules for JS/TS/React/Next/Node             |
+| [`@theholocron/holocron-config`](./packages/holocron-config)                 | Shareable holocron configuration presets           |
 | [`@theholocron/lint-staged-config`](./packages/lint-staged-config)           | Pre-commit lint-staged hooks                       |
 | [`@theholocron/prettier-config`](./packages/prettier-config)                 | Prettier formatting rules                          |
 | [`@theholocron/semantic-release-config`](./packages/semantic-release-config) | Semantic-release config for automated versioning   |

--- a/codecov.yml
+++ b/codecov.yml
@@ -43,6 +43,11 @@ component_management:
       paths:
         - packages/eslint-config/**
 
+    - component_id: holocron-config
+      name: "holocron-config"
+      paths:
+        - packages/holocron-config/**
+
     - component_id: lint-staged-config
       name: "lint-staged-config"
       paths:

--- a/packages/holocron-config/README.md
+++ b/packages/holocron-config/README.md
@@ -1,0 +1,44 @@
+# Holocron Config
+
+Shareable [holocron](https://github.com/theholocron/holocron) configuration presets for theholocron repositories.
+
+## Installation
+
+```bash
+pnpm add -D @theholocron/holocron-config @theholocron/cli
+```
+
+## Usage
+
+In your repo's `holocron.config.ts`, import the preset and spread each fragment into the unique parts for that repo:
+
+```ts
+import { defineConfig } from "@theholocron/cli";
+import type { HolocronConfig } from "@theholocron/cli";
+import { theholocronNode } from "@theholocron/holocron-config";
+
+const defaults = theholocronNode();
+export default defineConfig({
+  project: {
+    name: "my-repo",
+    description: "What this repo does.",
+    repo: "theholocron/my-repo",
+    repoPolicy: defaults.repoPolicy,
+    workflows: [
+      ...defaults.workflows,
+      { name: "release", with: { "run-build": true } },
+    ],
+  },
+  ...defaults.providers,
+} satisfies HolocronConfig);
+```
+
+`theholocronNode()` returns three fragments:
+
+| Fragment | Contents |
+| --- | --- |
+| `providers` | `source: "github"`, `ci: "github"`, `issues: ["github", { labels: … }]` |
+| `repoPolicy` | `preset: "strict"` |
+| `workflows` | `lint`, `test`, `typecheck`, `codeql`, `review`, `stale`, `greetings`, `dependencies`, `bookkeeping-pr` |
+
+Everything else — `project.name`, `project.description`, `project.repo`, and any per-repo workflow overrides (e.g. `release`) — stays in the consuming repo's config.

--- a/packages/holocron-config/README.md
+++ b/packages/holocron-config/README.md
@@ -35,10 +35,10 @@ export default defineConfig({
 
 `theholocronNode()` returns three fragments:
 
-| Fragment | Contents |
-| --- | --- |
-| `providers` | `source: "github"`, `ci: "github"`, `issues: ["github", { labels: … }]` |
-| `repoPolicy` | `preset: "strict"` |
-| `workflows` | `lint`, `test`, `typecheck`, `codeql`, `review`, `stale`, `greetings`, `dependencies`, `bookkeeping-pr` |
+| Fragment     | Contents                                                                                                |
+| ------------ | ------------------------------------------------------------------------------------------------------- |
+| `providers`  | `source: "github"`, `ci: "github"`, `issues: ["github", { labels: … }]`                                 |
+| `repoPolicy` | `preset: "strict"`                                                                                      |
+| `workflows`  | `lint`, `test`, `typecheck`, `codeql`, `review`, `stale`, `greetings`, `dependencies`, `bookkeeping-pr` |
 
 Everything else — `project.name`, `project.description`, `project.repo`, and any per-repo workflow overrides (e.g. `release`) — stays in the consuming repo's config.

--- a/packages/holocron-config/README.md
+++ b/packages/holocron-config/README.md
@@ -29,7 +29,7 @@ export default defineConfig({
       { name: "release", with: { "run-build": true } },
     ],
   },
-  ...defaults.providers,
+  providers: defaults.providers,
 } satisfies HolocronConfig);
 ```
 

--- a/packages/holocron-config/index.test.ts
+++ b/packages/holocron-config/index.test.ts
@@ -33,7 +33,9 @@ describe("theholocronNode()", () => {
 	describe("workflows", () => {
 		it("includes the baseline workflow set", () => {
 			const { workflows } = theholocronNode();
-			const names = workflows.map((w) => (typeof w === "string" ? w : w.name));
+			const names = workflows.map((w) =>
+				typeof w === "string" ? w : w.name,
+			);
 			for (const expected of [
 				"lint",
 				"test",
@@ -51,7 +53,9 @@ describe("theholocronNode()", () => {
 
 		it("does not include release (stays repo-specific)", () => {
 			const { workflows } = theholocronNode();
-			const names = workflows.map((w) => (typeof w === "string" ? w : w.name));
+			const names = workflows.map((w) =>
+				typeof w === "string" ? w : w.name,
+			);
 			expect(names).not.toContain("release");
 		});
 	});

--- a/packages/holocron-config/index.test.ts
+++ b/packages/holocron-config/index.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { theholocronNode } from "./index.js";
+
+describe("theholocronNode()", () => {
+	describe("providers", () => {
+		it("uses github for source and ci", () => {
+			const { providers } = theholocronNode();
+			expect(providers.source).toBe("github");
+			expect(providers.ci).toBe("github");
+		});
+
+		it("configures github issues with status labels", () => {
+			const { providers } = theholocronNode();
+			expect(providers.issues).toMatchObject([
+				"github",
+				{
+					labels: {
+						inProgress: "status:in-progress",
+						inReview: "status:in-review",
+					},
+				},
+			]);
+		});
+	});
+
+	describe("repoPolicy", () => {
+		it("sets strict preset", () => {
+			const { repoPolicy } = theholocronNode();
+			expect(repoPolicy.preset).toBe("strict");
+		});
+	});
+
+	describe("workflows", () => {
+		it("includes the baseline workflow set", () => {
+			const { workflows } = theholocronNode();
+			const names = workflows.map((w) => (typeof w === "string" ? w : w.name));
+			for (const expected of [
+				"lint",
+				"test",
+				"typecheck",
+				"codeql",
+				"review",
+				"stale",
+				"greetings",
+				"dependencies",
+				"bookkeeping-pr",
+			]) {
+				expect(names).toContain(expected);
+			}
+		});
+
+		it("does not include release (stays repo-specific)", () => {
+			const { workflows } = theholocronNode();
+			const names = workflows.map((w) => (typeof w === "string" ? w : w.name));
+			expect(names).not.toContain("release");
+		});
+	});
+});

--- a/packages/holocron-config/index.ts
+++ b/packages/holocron-config/index.ts
@@ -1,0 +1,55 @@
+import type { HolocronConfig } from "@theholocron/cli";
+
+export interface HolocronPreset {
+	providers: HolocronConfig["providers"];
+	repoPolicy: NonNullable<HolocronConfig["project"]["repoPolicy"]>;
+	workflows: NonNullable<HolocronConfig["project"]["workflows"]>;
+}
+
+/**
+ * Shared defaults for theholocron Node.js repositories.
+ * Spread the returned fragments into `defineConfig()` — only add what's unique per repo.
+ *
+ * @example
+ * const defaults = theholocronNode();
+ * export default defineConfig({
+ *   project: {
+ *     name: "my-repo",
+ *     repo: "theholocron/my-repo",
+ *     repoPolicy: defaults.repoPolicy,
+ *     workflows: [...defaults.workflows, { name: "release", with: { "run-build": true } }],
+ *   },
+ *   ...defaults.providers,
+ * } satisfies HolocronConfig);
+ */
+export function theholocronNode(): HolocronPreset {
+	return {
+		providers: {
+			source: "github",
+			ci: "github",
+			issues: [
+				"github",
+				{
+					labels: {
+						inProgress: "status:in-progress",
+						inReview: "status:in-review",
+					},
+				},
+			],
+		},
+		repoPolicy: {
+			preset: "strict",
+		},
+		workflows: [
+			"lint",
+			"test",
+			"typecheck",
+			"codeql",
+			"review",
+			"stale",
+			"greetings",
+			"dependencies",
+			"bookkeeping-pr",
+		],
+	};
+}

--- a/packages/holocron-config/index.ts
+++ b/packages/holocron-config/index.ts
@@ -19,7 +19,7 @@ export interface HolocronPreset {
  *     repoPolicy: defaults.repoPolicy,
  *     workflows: [...defaults.workflows, { name: "release", with: { "run-build": true } }],
  *   },
- *   ...defaults.providers,
+ *   providers: defaults.providers,
  * } satisfies HolocronConfig);
  */
 export function theholocronNode(): HolocronPreset {

--- a/packages/holocron-config/package.json
+++ b/packages/holocron-config/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@theholocron/holocron-config",
+  "version": "7.1.5",
+  "description": "Shareable holocron configuration presets for theholocron repositories.",
+  "homepage": "https://github.com/theholocron/configs/tree/main/packages/holocron-config#readme",
+  "bugs": "https://github.com/theholocron/configs/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/configs.git"
+  },
+  "license": "GPL-3.0",
+  "author": "Newton Koumantzelis",
+  "keywords": [
+    "holocron",
+    "config",
+    "preset",
+    "theholocron"
+  ],
+  "type": "module",
+  "scripts": {
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@theholocron/cli": "catalog:holocron",
+    "@theholocron/tsconfig": "workspace:*",
+    "@theholocron/vitest-config": "workspace:*",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@theholocron/cli": ">=2.0.0-alpha.1"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "releases": "https://github.com/theholocron/configs/releases",
+  "wiki": "https://github.com/theholocron/configs/wiki"
+}

--- a/packages/holocron-config/tsconfig.json
+++ b/packages/holocron-config/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@theholocron/tsconfig/node-lts",
+  "compilerOptions": { "rootDir": ".", "outDir": "dist" },
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules", "tsdown.config.ts"]
+}

--- a/packages/holocron-config/tsdown.config.ts
+++ b/packages/holocron-config/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown";
+export default defineConfig({
+	entry: ["index.ts"],
+	format: "esm",
+	fixedExtension: false,
+	dts: true,
+	clean: true,
+});

--- a/packages/holocron-config/vitest.config.ts
+++ b/packages/holocron-config/vitest.config.ts
@@ -1,0 +1,3 @@
+import { node } from "@theholocron/vitest-config";
+import { defineConfig } from "vitest/config";
+export default defineConfig(node());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,27 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
+  packages/holocron-config:
+    devDependencies:
+      '@theholocron/cli':
+        specifier: catalog:holocron
+        version: 2.0.0-alpha.42
+      '@theholocron/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@theholocron/vitest-config':
+        specifier: workspace:*
+        version: link:../vitest-config
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.9(tsx@4.23.1)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+
   packages/lint-staged-config:
     dependencies:
       lint-staged:


### PR DESCRIPTION
## Summary

- Adds `packages/holocron-config` — a new TypeScript package exporting `theholocronNode()`, which bundles the org-wide provider defaults, strict repo policy, and baseline workflow list
- Each consuming repo's `holocron.config.ts` can spread the preset fragments and only specify what's unique (repo name, topics, additional workflows like `release`)
- Adds the `holocron-config` Codecov component

## Usage

```ts
import { defineConfig } from "@theholocron/cli";
import type { HolocronConfig } from "@theholocron/cli";
import { theholocronNode } from "@theholocron/holocron-config";

const defaults = theholocronNode();
export default defineConfig({
  project: {
    name: "clients",
    description: "HTTP client packages for the Galaxy.",
    repo: "theholocron/clients",
    repoPolicy: defaults.repoPolicy,
    workflows: [...defaults.workflows, { name: "release", with: { "run-build": true } }],
  },
  providers: defaults.providers,
} satisfies HolocronConfig);
```

## Test plan

- [x] `pnpm --filter @theholocron/holocron-config typecheck` — passes
- [x] `pnpm --filter @theholocron/holocron-config test` — 5/5 tests pass
- [x] `pnpm --filter @theholocron/holocron-config build` — dist + .d.ts generated cleanly

Closes #262
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->