### PR TITLE
fix: add lcov reporter to vitest bundles for Codecov

### DIFF
--- a/packages/vitest-config/bundles/library.ts
+++ b/packages/vitest-config/bundles/library.ts
@@ -34,6 +34,7 @@ export function library({
 			...base.test,
 			coverage: {
 				provider: "v8",
+				reporter: ["lcov", "text"],
 				include: ["src/**/*.ts"],
 				exclude: [
 					"src/**/__tests__/**",

--- a/packages/vitest-config/bundles/react-app.ts
+++ b/packages/vitest-config/bundles/react-app.ts
@@ -16,6 +16,7 @@ export function reactApp(options = {}) {
 			...base.test,
 			coverage: {
 				provider: "v8",
+				reporter: ["lcov", "text"],
 				include: ["src/**"],
 				exclude: [
 					"**/*.{test,spec}.*",


### PR DESCRIPTION
## Summary

The `library()` and `reactApp()` vitest bundles had `provider: "v8"` configured but no `reporter`, so vitest used its default reporters (`text`, `json`, `html`). Codecov's uploader searches for `lcov.info` files and found zero, causing uploads to silently fail with "No coverage reports found."

Adds `reporter: ["lcov", "text"]` to both bundle coverage configs so Codecov can locate reports after every CI run.

## Test plan

- [x] `pnpm --filter @theholocron/vitest-config typecheck` — clean
- [x] `pnpm --filter @theholocron/vitest-config test` — 6/6 pass
- [x] `pnpm --filter @theholocron/vitest-config build` — clean
- [ ] Verify Codecov receives coverage on next CI run in `theholocron/clients` and `theholocron/holocron` after this releases
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->