### PR TITLE
fix: enable coverage by default in vitest bundles

### DIFF
--- a/packages/vitest-config/bundles/library.ts
+++ b/packages/vitest-config/bundles/library.ts
@@ -33,6 +33,7 @@ export function library({
 		test: {
 			...base.test,
 			coverage: {
+				enabled: true,
 				provider: "v8",
 				reporter: ["lcov", "text"],
 				include: ["src/**/*.ts"],

--- a/packages/vitest-config/bundles/react-app.ts
+++ b/packages/vitest-config/bundles/react-app.ts
@@ -15,6 +15,7 @@ export function reactApp(options = {}) {
 		test: {
 			...base.test,
 			coverage: {
+				enabled: true,
 				provider: "v8",
 				reporter: ["lcov", "text"],
 				include: ["src/**"],


### PR DESCRIPTION
## Summary

The reusable test workflow runs `pnpm test -- --coverage`, which pnpm passes to each package as `vitest run -- --coverage`. The `--` separator causes vitest to treat `--coverage` as a test file filter rather than a coverage flag — so coverage was never collected regardless of the lcov reporter being configured.

Adding `enabled: true` to the coverage config in both `library()` and `reactApp()` bundles makes coverage run on every `vitest run` without requiring the CLI flag, which is the correct behaviour for these bundles since they always want coverage.

## Test plan

- [x] `pnpm --filter @theholocron/vitest-config typecheck` — clean
- [x] `pnpm --filter @theholocron/vitest-config test` — 6/6 pass
- [x] `pnpm --filter @theholocron/vitest-config build` — clean
- [ ] Verify `lcov.info` files appear and Codecov receives reports on next CI run in `clients` and `holocron` after this releases
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->