### PR TITLE
fix: remove global thresholds from vitest bundles

### DIFF
--- a/packages/vitest-config/bundles/library.ts
+++ b/packages/vitest-config/bundles/library.ts
@@ -1,29 +1,9 @@
 import { defineConfig } from "vitest/config";
 import { node } from "../presets/node.js";
 
-// Thresholds accept global numbers and per-file overrides (nested objects).
-type Thresholds = Record<
-	string,
-	number | Record<string, number | undefined> | undefined
->;
-
-/**
- * Vitest bundle for published Node.js libraries.
- * Includes coverage with an 80% threshold on all metrics.
- *
- * Accepts per-file threshold overrides via `thresholds` in options:
- *
- * ```js
- * library({ thresholds: { "src/generated.ts": { lines: 0, functions: 0, branches: 0, statements: 0 } } })
- * ```
- *
- * @param {{ thresholds?: Thresholds, [key: string]: unknown }} [options]
- */
 export function library({
-	thresholds: thresholdOverrides,
 	...rest
 }: {
-	thresholds?: Thresholds;
 	[key: string]: unknown;
 } = {}) {
 	const base = node(rest);
@@ -44,13 +24,6 @@ export function library({
 					"**/node_modules/**",
 					"**/dist/**",
 				],
-				thresholds: {
-					lines: 80,
-					branches: 80,
-					functions: 80,
-					statements: 80,
-					...thresholdOverrides,
-				} as Thresholds,
 			},
 		},
 	};

--- a/packages/vitest-config/bundles/react-app.ts
+++ b/packages/vitest-config/bundles/react-app.ts
@@ -2,7 +2,6 @@ import { react } from "../presets/react.js";
 
 /**
  * Vitest bundle for React applications.
- * Includes jsdom environment and coverage with an 80% threshold.
  *
  * @param {import('vitest/config').UserProjectConfig['test']} [options]
  * @returns {import('vitest/config').UserProjectConfig}
@@ -25,12 +24,6 @@ export function reactApp(options = {}) {
 					"**/node_modules/**",
 					"**/dist/**",
 				],
-				thresholds: {
-					lines: 80,
-					branches: 80,
-					functions: 80,
-					statements: 80,
-				},
 			},
 		},
 	};

--- a/packages/vitest-config/index.test.ts
+++ b/packages/vitest-config/index.test.ts
@@ -34,27 +34,10 @@ describe("vitest-config — presets", () => {
 });
 
 describe("vitest-config — bundles", () => {
-	it("library() returns config with coverage thresholds", () => {
+	it("library() enables coverage with lcov reporter", () => {
 		const config = library();
-		expect(config.test?.coverage?.thresholds?.lines).toBe(80);
-		expect(config.test?.coverage?.thresholds?.branches).toBe(80);
-		expect(config.test?.coverage?.thresholds?.functions).toBe(80);
-		expect(config.test?.coverage?.thresholds?.statements).toBe(80);
-	});
-
-	it("library() accepts per-file threshold overrides", () => {
-		const config = library({
-			thresholds: {
-				"src/generated.ts": {
-					lines: 0,
-					functions: 0,
-					branches: 0,
-					statements: 0,
-				},
-			},
-		});
-		expect(
-			config.test?.coverage?.thresholds?.["src/generated.ts"],
-		).toBeDefined();
+		expect(config.test?.coverage?.enabled).toBe(true);
+		expect(config.test?.coverage?.provider).toBe("v8");
+		expect(config.test?.coverage?.reporter).toContain("lcov");
 	});
 });


### PR DESCRIPTION
## Summary

Removes the hardcoded 80% coverage thresholds from `library()` and `reactApp()`. Codecov already enforces threshold gates via `codecov.yml` component rules — having vitest also enforce thresholds with a different (and stricter) floor causes CI failures on packages that haven't reached 80% yet, which blocks coverage reporting entirely.

The bundles still collect coverage (`enabled: true`), output `lcov.info` for Codecov, and show a text summary in CI. Packages that want vitest-level thresholds can configure them explicitly in their own `vitest.config.ts`.

## Test plan

- [x] `pnpm --filter @theholocron/vitest-config typecheck` — clean
- [x] `pnpm --filter @theholocron/vitest-config test` — 5/5 pass
- [x] `pnpm --filter @theholocron/vitest-config build` — clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->