### PR TITLE
refactor(holocron-config): rename bookkeeping-pr workflow to bookkeeping

### DIFF
--- a/packages/holocron-config/configs/node.ts
+++ b/packages/holocron-config/configs/node.ts
@@ -52,7 +52,7 @@ export function node(): HolocronPreset {
 			"stale",
 			"greetings",
 			"dependencies",
-			"bookkeeping-pr",
+			"bookkeeping",
 		],
 	};
 }

--- a/packages/holocron-config/index.test.ts
+++ b/packages/holocron-config/index.test.ts
@@ -24,7 +24,7 @@ describe("node()", () => {
 				"stale",
 				"greetings",
 				"dependencies",
-				"bookkeeping-pr",
+				"bookkeeping",
 			]) {
 				expect(names).toContain(expected);
 			}


### PR DESCRIPTION
## Summary

Updates the `theholocronNode()` preset's default workflow list: `"bookkeeping-pr"` → `"bookkeeping"`.

Companion to theholocron/holocron#188, which renames the reusable workflow template and thin caller. Deploy sequence: merge holocron#188 first (new alpha), then merge this PR (new configs version), then bump both in consuming repos and run `holocron setup`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->