### PR TITLE
chore: use semver range for holocron catalog + sync description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 <!-- holocron:description -->
 
-Shared configuration packages for the theholocron organization.
+Shared configuration files.
 
 <!-- /holocron:description -->
-
-Shareable configuration used accross the Galaxy.
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # @theholocron/configs
 
 <!-- holocron:description -->
+
 Shared configuration packages for the theholocron organization.
+
 <!-- /holocron:description -->
 
 Shareable configuration used accross the Galaxy.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # @theholocron/configs
 
+<!-- holocron:description -->
+Shared configuration packages for the theholocron organization.
+<!-- /holocron:description -->
+
 Shareable configuration used accross the Galaxy.
 
 ## Packages

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -4,8 +4,7 @@ import { node } from "@theholocron/holocron-config";
 
 const { repo, workflows, providers } = node();
 export default defineConfig({
-	description:
-		"Shared configuration files.",
+	description: "Shared configuration files.",
 	repo: {
 		topics: [
 			"browserslist-config",

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -5,7 +5,7 @@ import { node } from "@theholocron/holocron-config";
 const { repo, workflows, providers } = node();
 export default defineConfig({
 	description:
-		"Shared configuration packages for the theholocron organization.",
+		"Shared configuration files.",
 	repo: {
 		topics: [
 			"browserslist-config",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@theholocron/configs",
   "version": "7.3.1",
   "private": true,
-  "description": "Shared configuration packages for the theholocron organization.",
+  "description": "Shared configuration files.",
   "keywords": [
     "browserslist-config",
     "commitlint-config",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@theholocron/configs",
   "version": "7.3.1",
   "private": true,
-  "description": "Shared configuration files.",
+  "description": "Shared configuration packages for the theholocron organization.",
   "keywords": [
     "browserslist-config",
     "commitlint-config",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,11 +20,11 @@ catalogs:
       version: 4.1.10
   holocron:
     '@theholocron/cli':
-      specifier: 2.0.0-alpha.56
-      version: 2.0.0-alpha.56
+      specifier: '>=2.0.0-alpha.0 <2.0.0'
+      version: 2.0.0-alpha.67
     '@theholocron/holocron-plugin-github':
-      specifier: 2.0.0-alpha.56
-      version: 2.0.0-alpha.56
+      specifier: '>=2.0.0-alpha.0 <2.0.0'
+      version: 2.0.0-alpha.67
 
 overrides:
   '@commitlint/config-conventional>conventional-changelog-conventionalcommits': '7'
@@ -58,7 +58,7 @@ importers:
         version: 12.0.9(semantic-release@25.0.7(typescript@5.9.3))
       '@theholocron/cli':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.56
+        version: 2.0.0-alpha.67
       '@theholocron/commitlint-config':
         specifier: workspace:*
         version: link:packages/commitlint-config
@@ -70,7 +70,7 @@ importers:
         version: link:packages/holocron-config
       '@theholocron/holocron-plugin-github':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.56(@theholocron/cli@2.0.0-alpha.56)(@theholocron/github-client@0.11.3)
+        version: 2.0.0-alpha.67(@theholocron/cli@2.0.0-alpha.67)(@theholocron/github-client@0.11.3)
       '@theholocron/lint-staged-config':
         specifier: workspace:*
         version: link:packages/lint-staged-config
@@ -191,7 +191,7 @@ importers:
     devDependencies:
       '@theholocron/cli':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.56
+        version: 2.0.0-alpha.67
       '@theholocron/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -2205,18 +2205,18 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@theholocron/cli@2.0.0-alpha.56':
-    resolution: {integrity: sha512-bu23IZqVhhzpvfX7ogCFmcq+QeeMj1DgEYhAZoSeB7WguKzTAFZaeF9yWU5mMiRXP+1byqB4lS/nvl19GcChMg==}
+  '@theholocron/cli@2.0.0-alpha.67':
+    resolution: {integrity: sha512-WRa+jWsp41Cb+QF7MdzmZ+Pm6GUe3ZQSqkUCQk72tAUimcDN6T+V3Q+kHDUVw/PHcJ8P2Dl4MM16dRo1WNohLg==}
     hasBin: true
 
   '@theholocron/github-client@0.11.3':
     resolution: {integrity: sha512-5XilkR1+0L0sE6/KGs2rGGvCPySKnYu0hRJ3vf6YRf1sz1kA2YPy9/zeZTArG0PVtF4GQWGZQ0DQCUvOWZAc6g==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.56':
-    resolution: {integrity: sha512-N3gKA1WOGWPWHmTe40c4JKal9OP6AIf3xxNDBiWhbVZCZ+M2ulxFl1I9KaXU9EMggopAFNNkVcvL8RrrZuHzxg==}
+  '@theholocron/holocron-plugin-github@2.0.0-alpha.67':
+    resolution: {integrity: sha512-gEGG5M4oxi5uqFImHFohqDB0U0vJYnaE9FK3BiqTu0gCir0UgiyW3/yr9p436HRcb1B+TmLyTOR4V+NB7pZT0g==}
     peerDependencies:
-      '@theholocron/cli': 2.0.0-alpha.56
+      '@theholocron/cli': 2.0.0-alpha.67
       '@theholocron/github-client': ^0.11.3
 
   '@theholocron/http-client@0.11.3':
@@ -2976,6 +2976,10 @@ packages:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
 
   cli-table3@0.6.5:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
@@ -4154,6 +4158,10 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
@@ -4223,6 +4231,10 @@ packages:
 
   is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
 
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
@@ -4645,6 +4657,10 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
+
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
@@ -4998,6 +5014,10 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
+    engines: {node: '>=18'}
 
   os-homedir@1.0.2:
     resolution: {integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==}
@@ -5680,6 +5700,10 @@ packages:
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -8144,11 +8168,13 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@theholocron/cli@2.0.0-alpha.56':
+  '@theholocron/cli@2.0.0-alpha.67':
     dependencies:
       '@napi-rs/keyring': 1.3.0
       '@theholocron/github-client': 0.11.3
       '@theholocron/http-client': 0.11.3
+      chalk: 5.6.2
+      ora: 8.2.0
       tsx: 4.23.1
       yargs: 18.0.0
 
@@ -8156,9 +8182,9 @@ snapshots:
     dependencies:
       '@theholocron/http-client': 0.6.2
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.56(@theholocron/cli@2.0.0-alpha.56)(@theholocron/github-client@0.11.3)':
+  '@theholocron/holocron-plugin-github@2.0.0-alpha.67(@theholocron/cli@2.0.0-alpha.67)(@theholocron/github-client@0.11.3)':
     dependencies:
-      '@theholocron/cli': 2.0.0-alpha.56
+      '@theholocron/cli': 2.0.0-alpha.67
       '@theholocron/github-client': 0.11.3
       libsodium-wrappers: 0.7.16
 
@@ -8953,6 +8979,8 @@ snapshots:
       parse5: 5.1.1
       parse5-htmlparser2-tree-adapter: 6.0.1
       yargs: 16.2.2
+
+  cli-spinners@2.9.2: {}
 
   cli-table3@0.6.5:
     dependencies:
@@ -10287,6 +10315,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-interactive@2.0.0: {}
+
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
@@ -10341,6 +10371,8 @@ snapshots:
       which-typed-array: 1.1.22
 
   is-typedarray@1.0.0: {}
+
+  is-unicode-supported@1.3.0: {}
 
   is-unicode-supported@2.1.0: {}
 
@@ -11015,6 +11047,11 @@ snapshots:
 
   lodash@4.18.1: {}
 
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.6.2
+      is-unicode-supported: 1.3.0
+
   log-update@6.1.0:
     dependencies:
       ansi-escapes: 7.3.0
@@ -11314,6 +11351,18 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
 
   os-homedir@1.0.2: {}
 
@@ -12072,6 +12121,8 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@4.2.0: {}
+
+  stdin-discarder@0.2.2: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,8 +4,8 @@ packages:
 # Holocron CLI and plugins — pinned in lockstep; bump together when running setup.
 catalogs:
   holocron:
-    '@theholocron/cli': 2.0.0-alpha.56
-    '@theholocron/holocron-plugin-github': 2.0.0-alpha.56
+    '@theholocron/cli': '>=2.0.0-alpha.0 <2.0.0'
+    '@theholocron/holocron-plugin-github': '>=2.0.0-alpha.0 <2.0.0'
 
 catalog:
   tsdown: ^0.22.8


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `2.0.0-alpha.56` pin in the holocron catalog with `>=2.0.0-alpha.0 <2.0.0` so new alpha releases are picked up automatically on `pnpm install`. The `<2.0.0` upper bound means it stays on alpha until the stable release, at which point the range can be updated to `^2.0.0`.
- Applies `holocron sync description` output: updates `package.json#description` and inserts the `<!-- holocron:description -->` block in `README.md`.

## Test plan

- [x] `pnpm exec holocron version` resolves to `2.0.0-alpha.67` (latest alpha)
- [x] `GITHUB_TOKEN=$(gh auth token) pnpm exec holocron sync description topics` — both steps `ok`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/configs/pull/278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->