### PR TITLE
chore: bump holocron plugin to alpha.71, run setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup.ts
-# Synced:  2026-07-21T18:25:42.832Z
+# Synced:  2026-07-21T21:58:21.681Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup.ts
-# Synced:  2026-07-21T18:25:42.828Z
+# Synced:  2026-07-21T21:58:21.680Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 

--- a/.github/workflows/bookkeeping.yml
+++ b/.github/workflows/bookkeeping.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T18:26:31.569Z
+# Synced:  2026-07-21T21:58:21.680Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Bookkeeping

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T18:26:31.565Z
+# Synced:  2026-07-21T21:58:21.678Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: CodeQL

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T18:26:31.568Z
+# Synced:  2026-07-21T21:58:21.679Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Dependencies

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T18:26:31.567Z
+# Synced:  2026-07-21T21:58:21.679Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Greetings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T18:26:31.559Z
+# Synced:  2026-07-21T21:58:21.674Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T20:57:36.249Z
-# Tool:    holocron sync-github
-# Changes: edit source in theholocron/holocron and push to alpha or main.
+# Synced:  2026-07-21T21:58:21.680Z
+# Tool:    holocron setup
+# Changes: run `holocron setup` to regenerate.
 name: Release
 
 on: # yamllint disable-line rule:truthy

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T18:26:31.565Z
+# Synced:  2026-07-21T21:58:21.678Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Review

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T18:26:31.566Z
+# Synced:  2026-07-21T21:58:21.679Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Stale

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T18:26:31.563Z
+# Synced:  2026-07-21T21:58:21.676Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Test

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T18:26:31.564Z
+# Synced:  2026-07-21T21:58:21.677Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Typecheck

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,10 +20,10 @@ catalogs:
       version: 4.1.10
   holocron:
     '@theholocron/cli':
-      specifier: 2.0.0-alpha.71
-      version: 2.0.0-alpha.69
+      specifier: '>=2.0.0-alpha.0 <2.0.0'
+      version: 2.0.0-alpha.71
     '@theholocron/holocron-plugin-github':
-      specifier: 2.0.0-alpha.71
+      specifier: '>=2.0.0-alpha.0 <2.0.0'
       version: 2.0.0-alpha.71
 
 overrides:
@@ -194,7 +194,7 @@ importers:
     devDependencies:
       '@theholocron/cli':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.69(vitest@4.1.10)
+        version: 2.0.0-alpha.71(vitest@4.1.10)
       '@theholocron/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -2207,10 +2207,6 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
-
-  '@theholocron/cli@2.0.0-alpha.69':
-    resolution: {integrity: sha512-bbMWW0HbULkad+HkqjudIHLc0L1PArQRUg4MJdjZ8NDAZSSI1GaVfxuxJHrb7ybjqDeJUhiXrACkktmDF9PjzQ==}
-    hasBin: true
 
   '@theholocron/cli@2.0.0-alpha.71':
     resolution: {integrity: sha512-/cCG4XgjDU+rW8Db+sqBUnN8wzAazHmk9n78IRYEgS0xu28AcgCPggDFKjgpWUbVemgoqRorMtuO+l8wOkm6qA==}
@@ -8179,18 +8175,6 @@ snapshots:
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
-
-  '@theholocron/cli@2.0.0-alpha.69(vitest@4.1.10)':
-    dependencies:
-      '@napi-rs/keyring': 1.3.0
-      '@theholocron/github-client': 1.1.0(vitest@4.1.10)
-      '@theholocron/http-client': 1.1.0(vitest@4.1.10)
-      chalk: 5.6.2
-      ora: 8.2.0
-      tsx: 4.23.1
-      yargs: 18.0.0
-    transitivePeerDependencies:
-      - vitest
 
   '@theholocron/cli@2.0.0-alpha.71(vitest@4.1.10)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,11 +20,11 @@ catalogs:
       version: 4.1.10
   holocron:
     '@theholocron/cli':
-      specifier: '>=2.0.0-alpha.0 <2.0.0'
+      specifier: 2.0.0-alpha.71
       version: 2.0.0-alpha.69
     '@theholocron/holocron-plugin-github':
-      specifier: '>=2.0.0-alpha.0 <2.0.0'
-      version: 2.0.0-alpha.0
+      specifier: 2.0.0-alpha.71
+      version: 2.0.0-alpha.71
 
 overrides:
   '@commitlint/config-conventional>conventional-changelog-conventionalcommits': '7'
@@ -58,7 +58,7 @@ importers:
         version: 12.0.9(semantic-release@25.0.7(typescript@5.9.3))
       '@theholocron/cli':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.69(vitest@4.1.10)
+        version: 2.0.0-alpha.71(vitest@4.1.10)
       '@theholocron/commitlint-config':
         specifier: workspace:*
         version: link:packages/commitlint-config
@@ -70,7 +70,7 @@ importers:
         version: link:packages/holocron-config
       '@theholocron/holocron-plugin-github':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.0(@theholocron/cli@2.0.0-alpha.69(vitest@4.1.10))
+        version: 2.0.0-alpha.71(@theholocron/cli@2.0.0-alpha.71(vitest@4.1.10))(@theholocron/github-client@1.1.0(vitest@4.1.10))
       '@theholocron/lint-staged-config':
         specifier: workspace:*
         version: link:packages/lint-staged-config
@@ -2212,14 +2212,19 @@ packages:
     resolution: {integrity: sha512-bbMWW0HbULkad+HkqjudIHLc0L1PArQRUg4MJdjZ8NDAZSSI1GaVfxuxJHrb7ybjqDeJUhiXrACkktmDF9PjzQ==}
     hasBin: true
 
+  '@theholocron/cli@2.0.0-alpha.71':
+    resolution: {integrity: sha512-/cCG4XgjDU+rW8Db+sqBUnN8wzAazHmk9n78IRYEgS0xu28AcgCPggDFKjgpWUbVemgoqRorMtuO+l8wOkm6qA==}
+    hasBin: true
+
   '@theholocron/github-client@1.1.0':
     resolution: {integrity: sha512-lgx91s07K1mxJoZra91c8KlLxNO1XAezCYd5ma7B7YmscKKlo++kjmjycPKetfWICPFiGMTyaY5Pz6MPpGKT5g==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.0':
-    resolution: {integrity: sha512-rBVmU6Lz/hXeOiCHW47VpkbcqGWGGaFCIyLvBXHc+ERugZzbCGjBEYSvrzfeOAD5m8nmRDeZnHZU2RGyli05xA==}
+  '@theholocron/holocron-plugin-github@2.0.0-alpha.71':
+    resolution: {integrity: sha512-kDxy1QpfB786C8eKkjpJceSxJ2Ym0aK9b7gxSGpvH8X4mQ6FLvncpROJoHkHDdbK8Ql2jpWpQWI+OTkxUKh0IA==}
     peerDependencies:
-      '@theholocron/cli': 2.0.0-alpha.0
+      '@theholocron/cli': 2.0.0-alpha.71
+      '@theholocron/github-client': ^1.1.0
 
   '@theholocron/http-client@1.1.0':
     resolution: {integrity: sha512-ph/lgmMfbO34j5tIAFNFI5Ykvl/ruQcjN/w/3BdNinsFnJvNHXRBaZ2YPSdLNCEdLymmAq8h3oY7UxihfkyqeQ==}
@@ -8187,15 +8192,28 @@ snapshots:
     transitivePeerDependencies:
       - vitest
 
+  '@theholocron/cli@2.0.0-alpha.71(vitest@4.1.10)':
+    dependencies:
+      '@napi-rs/keyring': 1.3.0
+      '@theholocron/github-client': 1.1.0(vitest@4.1.10)
+      '@theholocron/http-client': 1.1.0(vitest@4.1.10)
+      chalk: 5.6.2
+      ora: 8.2.0
+      tsx: 4.23.1
+      yargs: 18.0.0
+    transitivePeerDependencies:
+      - vitest
+
   '@theholocron/github-client@1.1.0(vitest@4.1.10)':
     dependencies:
       '@theholocron/http-client': 1.1.0(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.0(@theholocron/cli@2.0.0-alpha.69(vitest@4.1.10))':
+  '@theholocron/holocron-plugin-github@2.0.0-alpha.71(@theholocron/cli@2.0.0-alpha.71(vitest@4.1.10))(@theholocron/github-client@1.1.0(vitest@4.1.10))':
     dependencies:
-      '@theholocron/cli': 2.0.0-alpha.69(vitest@4.1.10)
+      '@theholocron/cli': 2.0.0-alpha.71(vitest@4.1.10)
+      '@theholocron/github-client': 1.1.0(vitest@4.1.10)
       libsodium-wrappers: 0.7.16
 
   '@theholocron/http-client@1.1.0(vitest@4.1.10)':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,5 +10,5 @@ catalog:
 # Holocron CLI and plugins — pinned in lockstep; bump together when running setup.
 catalogs:
   holocron:
-    '@theholocron/cli': '>=2.0.0-alpha.0 <2.0.0'
-    '@theholocron/holocron-plugin-github': '>=2.0.0-alpha.0 <2.0.0'
+    '@theholocron/cli': '2.0.0-alpha.71'
+    '@theholocron/holocron-plugin-github': '2.0.0-alpha.71'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,5 +10,5 @@ catalog:
 # Holocron CLI and plugins — pinned in lockstep; bump together when running setup.
 catalogs:
   holocron:
-    '@theholocron/cli': '2.0.0-alpha.71'
-    '@theholocron/holocron-plugin-github': '2.0.0-alpha.71'
+    '@theholocron/cli': '>=2.0.0-alpha.0 <2.0.0'
+    '@theholocron/holocron-plugin-github': '>=2.0.0-alpha.0 <2.0.0'


### PR DESCRIPTION
## Summary

- Bumps `@theholocron/holocron-plugin-github` catalog pin to `2.0.0-alpha.71` (in lockstep with CLI)
- Re-runs `holocron setup`: 30 ok, 0 fail, 0 skipped — `sync teams` registers repo with `gatekeepers`, skills installed