### PR TITLE
chore: bump holocron cli to 2.1.1, add turborepo skill, run setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup.ts
-# Synced:  2026-07-21T21:58:21.681Z
+# Synced:  2026-07-22T15:53:01.106Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup.ts
-# Synced:  2026-07-21T21:58:21.680Z
+# Synced:  2026-07-22T15:53:01.104Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 

--- a/.github/workflows/bookkeeping.yml
+++ b/.github/workflows/bookkeeping.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:58:21.680Z
+# Synced:  2026-07-22T15:53:01.103Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Bookkeeping

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:58:21.678Z
+# Synced:  2026-07-22T15:53:01.102Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: CodeQL

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:58:21.679Z
+# Synced:  2026-07-22T15:53:01.103Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Dependencies

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:58:21.679Z
+# Synced:  2026-07-22T15:53:01.103Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Greetings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:58:21.674Z
+# Synced:  2026-07-22T15:53:01.097Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-22T06:20:23.059Z
-# Tool:    holocron sync-github
-# Changes: edit source in theholocron/holocron and push to alpha or main.
+# Synced:  2026-07-22T15:53:01.104Z
+# Tool:    holocron setup
+# Changes: run `holocron setup` to regenerate.
 name: Release
 
 on: # yamllint disable-line rule:truthy

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:58:21.678Z
+# Synced:  2026-07-22T15:53:01.102Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Review

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:58:21.679Z
+# Synced:  2026-07-22T15:53:01.103Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Stale

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:58:21.676Z
+# Synced:  2026-07-22T15:53:01.101Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Test

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-21T21:58:21.677Z
+# Synced:  2026-07-22T15:53:01.102Z
 # Tool:    holocron setup
 # Changes: run `holocron setup` to regenerate.
 name: Typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -96,4 +96,5 @@ test-report.junit.xml
 /.claude/skills/commit-standards
 /.claude/skills/security-review
 /.claude/skills/holocron-skill-config
+/.claude/skills/turborepo
 # end managed by holocron setup — skills

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -35,5 +35,6 @@ export default defineConfig({
 		"commit-standards",
 		"security-review",
 		"holocron-skill-config",
+		"turborepo",
 	],
 } satisfies HolocronConfig);

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@semantic-release/git": "^11.0.0",
     "@semantic-release/github": "^12.0.9",
     "@theholocron/cli": "catalog:holocron",
-    "@theholocron/skills": "^1.0.0",
+    "@theholocron/skills": "^1.1.3",
     "@theholocron/commitlint-config": "workspace:*",
     "@theholocron/eslint-config": "workspace:*",
     "@theholocron/holocron-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,11 +20,11 @@ catalogs:
       version: 4.1.10
   holocron:
     '@theholocron/cli':
-      specifier: '>=2.0.0-alpha.0 <2.0.0'
-      version: 2.0.0-alpha.71
+      specifier: ^2.1.1
+      version: 2.1.1
     '@theholocron/holocron-plugin-github':
-      specifier: '>=2.0.0-alpha.0 <2.0.0'
-      version: 2.0.0-alpha.71
+      specifier: ^2.1.1
+      version: 2.1.1
 
 overrides:
   '@commitlint/config-conventional>conventional-changelog-conventionalcommits': '7'
@@ -58,7 +58,7 @@ importers:
         version: 12.0.9(semantic-release@25.0.8(typescript@5.9.3))
       '@theholocron/cli':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.71(vitest@4.1.10)
+        version: 2.1.1(vitest@4.1.10)
       '@theholocron/commitlint-config':
         specifier: workspace:*
         version: link:packages/commitlint-config
@@ -70,7 +70,7 @@ importers:
         version: link:packages/holocron-config
       '@theholocron/holocron-plugin-github':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.71(@theholocron/cli@2.0.0-alpha.71(vitest@4.1.10))(@theholocron/github-client@1.1.0(vitest@4.1.10))
+        version: 2.1.1(@theholocron/cli@2.1.1(vitest@4.1.10))(@theholocron/github-client@1.3.3(vitest@4.1.10))
       '@theholocron/lint-staged-config':
         specifier: workspace:*
         version: link:packages/lint-staged-config
@@ -78,8 +78,8 @@ importers:
         specifier: workspace:*
         version: link:packages/semantic-release-config
       '@theholocron/skills':
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.1.3
+        version: 1.1.3
       conventional-changelog-conventionalcommits:
         specifier: ^10.2.1
         version: 10.2.1
@@ -160,7 +160,7 @@ importers:
         version: 7.37.5(eslint@10.7.0(jiti@2.6.1))
       eslint-plugin-storybook:
         specifier: ^10
-        version: 10.5.0(eslint@10.7.0(jiti@2.6.1))(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3)
+        version: 10.5.0(eslint@10.7.0(jiti@2.6.1))(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3)
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.0
@@ -188,13 +188,13 @@ importers:
         version: 8.65.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/holocron-config:
     devDependencies:
       '@theholocron/cli':
         specifier: catalog:holocron
-        version: 2.0.0-alpha.71(vitest@4.1.10)
+        version: 2.1.1(vitest@4.1.10)
       '@theholocron/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -485,7 +485,7 @@ importers:
     dependencies:
       '@storybook/addon-vitest':
         specifier: ^9
-        version: 9.1.20(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(vitest@4.1.10)
+        version: 9.1.20(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(vitest@4.1.10)
       '@testing-library/react':
         specifier: ^16
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -494,7 +494,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/browser':
         specifier: ^4
-        version: 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+        version: 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
       jsdom:
         specifier: ^26
         version: 26.1.0
@@ -516,7 +516,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
@@ -2324,22 +2324,22 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@theholocron/cli@2.0.0-alpha.71':
-    resolution: {integrity: sha512-/cCG4XgjDU+rW8Db+sqBUnN8wzAazHmk9n78IRYEgS0xu28AcgCPggDFKjgpWUbVemgoqRorMtuO+l8wOkm6qA==}
+  '@theholocron/cli@2.1.1':
+    resolution: {integrity: sha512-rjIiTf78Z1m39IW6P6Fq1r7CYDRJ+era+XBjg9aEm9K1BhAHXOy9zODekHPkVO74sRtRoR4qUw38muszeBnvHw==}
     hasBin: true
 
-  '@theholocron/github-client@1.1.0':
-    resolution: {integrity: sha512-lgx91s07K1mxJoZra91c8KlLxNO1XAezCYd5ma7B7YmscKKlo++kjmjycPKetfWICPFiGMTyaY5Pz6MPpGKT5g==}
+  '@theholocron/github-client@1.3.3':
+    resolution: {integrity: sha512-BVl30n6yB3TsJvGpSrwIk/pUDjcGJ9ou/lhWCdMC/I4B0DsTLtuQIAEBfmkwEdNa36oOeQYnRYQbGsfKcAuKlQ==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.71':
-    resolution: {integrity: sha512-kDxy1QpfB786C8eKkjpJceSxJ2Ym0aK9b7gxSGpvH8X4mQ6FLvncpROJoHkHDdbK8Ql2jpWpQWI+OTkxUKh0IA==}
+  '@theholocron/holocron-plugin-github@2.1.1':
+    resolution: {integrity: sha512-yND4TdjgUuMGhhy1GLGWosaIdzJzxJFVtccOULbK7NN1ZmNRcMoLhH63GLxt8wWYFsUKs1cRlUg4niJdI2vKiA==}
     peerDependencies:
-      '@theholocron/cli': 2.0.0-alpha.71
-      '@theholocron/github-client': ^1.1.0
+      '@theholocron/cli': 2.1.1
+      '@theholocron/github-client': ^1.3.0
 
-  '@theholocron/http-client@1.1.0':
-    resolution: {integrity: sha512-ph/lgmMfbO34j5tIAFNFI5Ykvl/ruQcjN/w/3BdNinsFnJvNHXRBaZ2YPSdLNCEdLymmAq8h3oY7UxihfkyqeQ==}
+  '@theholocron/http-client@1.3.3':
+    resolution: {integrity: sha512-ZEr/4bRSZNFwd8yP55AvhlYVyckfcL/vv5yYfm2huoVcP3lEG+Q7ODlEikvcpKQu4wUyUv0kLfgISdW3lOUiRA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       vitest: '>=4.0.0'
@@ -2347,8 +2347,8 @@ packages:
       vitest:
         optional: true
 
-  '@theholocron/skills@1.0.0':
-    resolution: {integrity: sha512-tk+3U0eJLzDSVIEcr08j1+GbSUb/HExLZrwFrWDKoYTFWhVHnk6SID+JobqwUfGSlVn65ffK7EFiUqYBIKQmbA==}
+  '@theholocron/skills@1.1.3':
+    resolution: {integrity: sha512-Hs4+upY6yoVWZPOeIepNfcbCsPShIU/mgukV5bmvX0ViCFJoqdoJQrlcQpb23fyedJyl3zLdtNLkPYjZ24GHGg==}
     engines: {node: '>=22', pnpm: '>=10'}
 
   '@turbo/darwin-64@2.10.5':
@@ -4744,11 +4744,11 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  libsodium-wrappers@0.7.16:
-    resolution: {integrity: sha512-Gtr/WBx4dKjvRL1pvfwZqu7gO6AfrQ0u9vFL+kXihtHf6NfkROR8pjYWn98MFDI3jN19Ii1ZUfPR9afGiPyfHg==}
+  libsodium-wrappers@0.8.4:
+    resolution: {integrity: sha512-mu8aAWucZjTB5O/BtGXtW4e1agy7uHxNYG7zPthmmD1jU43LCDmSWZLN4JhflbdPXj3yDO4lxM1O9hLDgIOXDw==}
 
-  libsodium@0.7.16:
-    resolution: {integrity: sha512-3HrzSPuzm6Yt9aTYCDxYEG8x8/6C0+ag655Y7rhhWZM9PT4NpdnbqlzXhGZlDnkgR6MeSTnOt/VIyHLs9aSf+Q==}
+  libsodium@0.8.4:
+    resolution: {integrity: sha512-lMcYaRi0zcs7tarATsQUYC7rstliIXZuoq0c6zXSgNtSNtdvBgkSegjWhpMJAXzKX3SUSwIp7+zEsob+j3LuRw==}
 
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
@@ -6303,6 +6303,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tsx@4.23.1:
     resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
@@ -8384,6 +8389,21 @@ snapshots:
       storybook: 9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
       ts-dedent: 2.3.0
 
+  '@storybook/addon-vitest@9.1.20(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(vitest@4.1.10)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 1.6.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      prompts: 2.4.2
+      storybook: 9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+      ts-dedent: 2.3.0
+    optionalDependencies:
+      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/runner': 4.1.10
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@storybook/addon-vitest@9.1.20(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(vitest@4.1.10)':
     dependencies:
       '@storybook/global': 5.0.0
@@ -8584,35 +8604,35 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@theholocron/cli@2.0.0-alpha.71(vitest@4.1.10)':
+  '@theholocron/cli@2.1.1(vitest@4.1.10)':
     dependencies:
       '@napi-rs/keyring': 1.3.0
-      '@theholocron/github-client': 1.1.0(vitest@4.1.10)
-      '@theholocron/http-client': 1.1.0(vitest@4.1.10)
+      '@theholocron/github-client': 1.3.3(vitest@4.1.10)
+      '@theholocron/http-client': 1.3.3(vitest@4.1.10)
       chalk: 5.6.2
       ora: 8.2.0
-      tsx: 4.23.1
+      tsx: 4.22.4
       yargs: 18.0.0
     transitivePeerDependencies:
       - vitest
 
-  '@theholocron/github-client@1.1.0(vitest@4.1.10)':
+  '@theholocron/github-client@1.3.3(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.1.0(vitest@4.1.10)
+      '@theholocron/http-client': 1.3.3(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
-  '@theholocron/holocron-plugin-github@2.0.0-alpha.71(@theholocron/cli@2.0.0-alpha.71(vitest@4.1.10))(@theholocron/github-client@1.1.0(vitest@4.1.10))':
+  '@theholocron/holocron-plugin-github@2.1.1(@theholocron/cli@2.1.1(vitest@4.1.10))(@theholocron/github-client@1.3.3(vitest@4.1.10))':
     dependencies:
-      '@theholocron/cli': 2.0.0-alpha.71(vitest@4.1.10)
-      '@theholocron/github-client': 1.1.0(vitest@4.1.10)
-      libsodium-wrappers: 0.7.16
+      '@theholocron/cli': 2.1.1(vitest@4.1.10)
+      '@theholocron/github-client': 1.3.3(vitest@4.1.10)
+      libsodium-wrappers: 0.8.4
 
-  '@theholocron/http-client@1.1.0(vitest@4.1.10)':
+  '@theholocron/http-client@1.3.3(vitest@4.1.10)':
     optionalDependencies:
       vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
-  '@theholocron/skills@1.0.0': {}
+  '@theholocron/skills@1.1.3': {}
 
   '@turbo/darwin-64@2.10.5':
     optional: true
@@ -8871,6 +8891,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/browser@4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
   '@vitest/browser@4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
@@ -8887,6 +8924,7 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
   '@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)':
     dependencies:
@@ -8912,7 +8950,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -10078,12 +10116,12 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-storybook@10.5.0(eslint@10.7.0(jiti@2.6.1))(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3):
+  eslint-plugin-storybook@10.5.0(eslint@10.7.0(jiti@2.6.1))(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/utils': 8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 10.7.0(jiti@2.6.1)
-      storybook: 9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+      storybook: 9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11448,11 +11486,11 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  libsodium-wrappers@0.7.16:
+  libsodium-wrappers@0.8.4:
     dependencies:
-      libsodium: 0.7.16
+      libsodium: 0.8.4
 
-  libsodium@0.7.16: {}
+  libsodium@0.8.4: {}
 
   lightningcss-android-arm64@1.33.0:
     optional: true
@@ -13142,11 +13180,18 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tsx@4.23.1:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
+    optional: true
 
   tunnel@0.0.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,5 +10,5 @@ catalog:
 # Holocron CLI and plugins — pinned in lockstep; bump together when running setup.
 catalogs:
   holocron:
-    '@theholocron/cli': '>=2.0.0-alpha.0 <2.0.0'
-    '@theholocron/holocron-plugin-github': '>=2.0.0-alpha.0 <2.0.0'
+    '@theholocron/cli': ^2.1.1
+    '@theholocron/holocron-plugin-github': ^2.1.1


### PR DESCRIPTION
## Summary

- Bumps `@theholocron/cli` and `@theholocron/holocron-plugin-github` to `^2.1.1` in `pnpm-workspace.yaml` (was `>=2.0.0-alpha.0 <2.0.0` — the old alpha range matched no stable release)
- Bumps `@theholocron/skills` from `^1.0.0` to `^1.1.3`
- Adds `"turborepo"` to `skills` in `holocron.config.ts`
- Runs `holocron setup` — installs all 6 skills including the external turborepo skill (noted as stale; run `holocron skills update` to refresh the lock hash)

## Test plan

- [ ] CI green
- [ ] `holocron setup` output files (workflows, .editorconfig, .gitignore) match what CI expects