### PR TITLE
feat(semantic-release-config): add npm option for single-package repos

### DIFF
--- a/packages/semantic-release-config/index.test.ts
+++ b/packages/semantic-release-config/index.test.ts
@@ -49,5 +49,68 @@ describe("semantic-release-config", () => {
 			};
 			expect(config.branches).toContain("alpha");
 		});
+
+		it("includes monorepo packages glob in git assets by default", () => {
+			const config = defineConfig() as { plugins: unknown[] };
+			const git = config.plugins.find(
+				(p) => Array.isArray(p) && p[0] === "@semantic-release/git",
+			) as [string, { assets: string[] }];
+			expect(git[1].assets).toContain("packages/*/package.json");
+		});
+
+		describe("npm option", () => {
+			it("inserts @semantic-release/npm with access: public when npm: true", () => {
+				const config = defineConfig({ npm: true }) as { plugins: unknown[] };
+				const npm = config.plugins.find(
+					(p) => Array.isArray(p) && p[0] === "@semantic-release/npm",
+				) as [string, { access: string }];
+				expect(npm).toBeDefined();
+				expect(npm[1].access).toBe("public");
+			});
+
+			it("places @semantic-release/npm after changelog and before git", () => {
+				const config = defineConfig({ npm: true }) as { plugins: unknown[] };
+				const plugins = config.plugins as unknown[];
+				const changelogIdx = plugins.indexOf("@semantic-release/changelog");
+				const npmIdx = plugins.findIndex(
+					(p) => Array.isArray(p) && (p as unknown[])[0] === "@semantic-release/npm",
+				);
+				const gitIdx = plugins.findIndex(
+					(p) => Array.isArray(p) && (p as unknown[])[0] === "@semantic-release/git",
+				);
+				expect(npmIdx).toBeGreaterThan(changelogIdx);
+				expect(npmIdx).toBeLessThan(gitIdx);
+			});
+
+			it("accepts npm options object", () => {
+				const config = defineConfig({ npm: { access: "restricted" } }) as {
+					plugins: unknown[];
+				};
+				const npm = config.plugins.find(
+					(p) => Array.isArray(p) && p[0] === "@semantic-release/npm",
+				) as [string, { access: string }];
+				expect(npm[1].access).toBe("restricted");
+			});
+
+			it("uses single-package assets when npm is set", () => {
+				const config = defineConfig({ npm: true }) as { plugins: unknown[] };
+				const git = config.plugins.find(
+					(p) => Array.isArray(p) && p[0] === "@semantic-release/git",
+				) as [string, { assets: string[] }];
+				expect(git[1].assets).not.toContain("packages/*/package.json");
+				expect(git[1].assets).toContain("package.json");
+			});
+
+			it("allows assets override even when npm is set", () => {
+				const config = defineConfig({
+					npm: true,
+					assets: ["CHANGELOG.md", "package.json", "dist/"],
+				}) as { plugins: unknown[] };
+				const git = config.plugins.find(
+					(p) => Array.isArray(p) && p[0] === "@semantic-release/git",
+				) as [string, { assets: string[] }];
+				expect(git[1].assets).toContain("dist/");
+			});
+		});
 	});
 });

--- a/packages/semantic-release-config/index.test.ts
+++ b/packages/semantic-release-config/index.test.ts
@@ -60,7 +60,9 @@ describe("semantic-release-config", () => {
 
 		describe("npm option", () => {
 			it("inserts @semantic-release/npm with access: public when npm: true", () => {
-				const config = defineConfig({ npm: true }) as { plugins: unknown[] };
+				const config = defineConfig({ npm: true }) as {
+					plugins: unknown[];
+				};
 				const npm = config.plugins.find(
 					(p) => Array.isArray(p) && p[0] === "@semantic-release/npm",
 				) as [string, { access: string }];
@@ -69,21 +71,31 @@ describe("semantic-release-config", () => {
 			});
 
 			it("places @semantic-release/npm after changelog and before git", () => {
-				const config = defineConfig({ npm: true }) as { plugins: unknown[] };
+				const config = defineConfig({ npm: true }) as {
+					plugins: unknown[];
+				};
 				const plugins = config.plugins as unknown[];
-				const changelogIdx = plugins.indexOf("@semantic-release/changelog");
+				const changelogIdx = plugins.indexOf(
+					"@semantic-release/changelog",
+				);
 				const npmIdx = plugins.findIndex(
-					(p) => Array.isArray(p) && (p as unknown[])[0] === "@semantic-release/npm",
+					(p) =>
+						Array.isArray(p) &&
+						(p as unknown[])[0] === "@semantic-release/npm",
 				);
 				const gitIdx = plugins.findIndex(
-					(p) => Array.isArray(p) && (p as unknown[])[0] === "@semantic-release/git",
+					(p) =>
+						Array.isArray(p) &&
+						(p as unknown[])[0] === "@semantic-release/git",
 				);
 				expect(npmIdx).toBeGreaterThan(changelogIdx);
 				expect(npmIdx).toBeLessThan(gitIdx);
 			});
 
 			it("accepts npm options object", () => {
-				const config = defineConfig({ npm: { access: "restricted" } }) as {
+				const config = defineConfig({
+					npm: { access: "restricted" },
+				}) as {
 					plugins: unknown[];
 				};
 				const npm = config.plugins.find(
@@ -93,7 +105,9 @@ describe("semantic-release-config", () => {
 			});
 
 			it("uses single-package assets when npm is set", () => {
-				const config = defineConfig({ npm: true }) as { plugins: unknown[] };
+				const config = defineConfig({ npm: true }) as {
+					plugins: unknown[];
+				};
 				const git = config.plugins.find(
 					(p) => Array.isArray(p) && p[0] === "@semantic-release/git",
 				) as [string, { assets: string[] }];

--- a/packages/semantic-release-config/index.ts
+++ b/packages/semantic-release-config/index.ts
@@ -2,9 +2,15 @@ interface ExecOptions {
 	prepareCmd?: string;
 	publishCmd?: string;
 }
+interface NpmOptions {
+	access?: "public" | "restricted";
+	pkgRoot?: string;
+	tarballDir?: string;
+}
 interface Options {
 	branches?: Array<string | Record<string, unknown>>;
 	exec?: ExecOptions;
+	npm?: boolean | NpmOptions;
 	assets?: string[];
 }
 
@@ -43,6 +49,7 @@ const defaultAssets = [
 	"package.json",
 	"packages/*/package.json",
 ];
+const defaultSingleAssets = ["CHANGELOG.md", "package.json"];
 const defaultMessage =
 	"chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}\n\nSigned-off-by: Newton <5769156+iamnewton@users.noreply.github.com>";
 
@@ -52,16 +59,23 @@ const defaultMessage =
 export function defineConfig({
 	branches = ["main"],
 	exec,
-	assets = defaultAssets,
+	npm,
+	assets,
 }: Options = {}): object {
+	const npmOptions: NpmOptions =
+		npm === true ? { access: "public" } : npm || {};
+	const resolvedAssets =
+		assets ?? (npm ? defaultSingleAssets : defaultAssets);
+
 	return {
 		branches,
 		plugins: [
 			commitAnalyzer,
 			releaseNotesGenerator,
 			"@semantic-release/changelog",
+			...(npm ? [["@semantic-release/npm", npmOptions]] : []),
 			...(exec ? [["@semantic-release/exec", exec]] : []),
-			["@semantic-release/git", { assets, message: defaultMessage }],
+			["@semantic-release/git", { assets: resolvedAssets, message: defaultMessage }],
 			"@semantic-release/github",
 		],
 	};

--- a/packages/semantic-release-config/index.ts
+++ b/packages/semantic-release-config/index.ts
@@ -75,7 +75,10 @@ export function defineConfig({
 			"@semantic-release/changelog",
 			...(npm ? [["@semantic-release/npm", npmOptions]] : []),
 			...(exec ? [["@semantic-release/exec", exec]] : []),
-			["@semantic-release/git", { assets: resolvedAssets, message: defaultMessage }],
+			[
+				"@semantic-release/git",
+				{ assets: resolvedAssets, message: defaultMessage },
+			],
 			"@semantic-release/github",
 		],
 	};


### PR DESCRIPTION
## Summary

- Adds `npm` option to `defineConfig` — accepts `true` or an `NpmOptions` object (`access`, `pkgRoot`, `tarballDir`)
- When `npm` is set, inserts `@semantic-release/npm` between `@semantic-release/changelog` and `@semantic-release/git` in the plugin chain
- Defaults `access` to `"public"` when `npm: true`
- Automatically uses a single-package asset list (`CHANGELOG.md`, `package.json`) instead of the monorepo glob (`packages/*/package.json`) — overridable via `assets`

Enables single-package repos (e.g. `theholocron/skills`) to use `defineConfig({ npm: true })` instead of manually splicing plugins, fixing version bumping and OIDC provenance publishing. Refs theholocron/skills#11.

## Test plan

- [x] All existing tests pass
- [x] New tests cover: plugin insertion, ordering, options passthrough, asset defaults, asset override