### PR TITLE
feat(eslint-config): enforce import ordering via simple-import-sort

### DIFF
--- a/packages/eslint-config/configs/base.ts
+++ b/packages/eslint-config/configs/base.ts
@@ -1,7 +1,9 @@
 import js from "@eslint/js";
+import type { Linter } from "eslint";
 import globals from "globals";
+import simpleImportSort from "eslint-plugin-simple-import-sort";
 
-export function base() {
+export function base(): Linter.Config[] {
 	return [
 		{
 			name: "@theholocron/base",
@@ -13,5 +15,15 @@ export function base() {
 			},
 		},
 		js.configs.recommended,
+		{
+			name: "@theholocron/imports",
+			plugins: {
+				"simple-import-sort": simpleImportSort,
+			},
+			rules: {
+				"simple-import-sort/imports": "error",
+				"simple-import-sort/exports": "error",
+			},
+		},
 	];
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -27,15 +27,16 @@
     "test": "vitest run"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.0",
     "@theholocron/tsconfig": "workspace:*",
-    "tsdown": "catalog:",
-    "typescript": "catalog:",
-    "vitest": "catalog:",
     "@theholocron/vitest-config": "workspace:*",
     "@vitest/coverage-v8": "catalog:",
-    "@eslint/js": "^10.0.0",
+    "eslint-plugin-simple-import-sort": "^14.0.0",
     "globals": "^17.0.0",
-    "typescript-eslint": "^8.65.0"
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "typescript-eslint": "^8.65.0",
+    "vitest": "catalog:"
   },
   "exports": {
     ".": {
@@ -117,6 +118,7 @@
     "eslint-plugin-n": "^18",
     "eslint-plugin-react": "^7",
     "eslint-plugin-storybook": "^10",
+    "eslint-plugin-simple-import-sort": "^14",
     "globals": "^17",
     "typescript-eslint": "^8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+      eslint-plugin-simple-import-sort:
+        specifier: ^14.0.0
+        version: 14.0.0(eslint@10.7.0(jiti@2.6.1))
       globals:
         specifier: ^17.0.0
         version: 17.7.0
@@ -3662,6 +3665,11 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-plugin-simple-import-sort@14.0.0:
+    resolution: {integrity: sha512-NUJO0+XFCkk+o5EsAJruTgnfMEpeWrPWeJS15UVF60GgXmqz1BJ9/3hzlvG7lkL8Bubzos5cCLptThbFfPnSMQ==}
+    peerDependencies:
+      eslint: '>=5.0.0'
 
   eslint-plugin-storybook@10.5.0:
     resolution: {integrity: sha512-UyhbK11baKAYqzyDUHlwDlm1aP/wxPMR0vFmsxA5984BGaPwarhoXUWng1Xa0cd9BdPbQ+zr/y8ADk6XxtwkYg==}
@@ -10115,6 +10123,10 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
+
+  eslint-plugin-simple-import-sort@14.0.0(eslint@10.7.0(jiti@2.6.1)):
+    dependencies:
+      eslint: 10.7.0(jiti@2.6.1)
 
   eslint-plugin-storybook@10.5.0(eslint@10.7.0(jiti@2.6.1))(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `eslint-plugin-simple-import-sort` to the `base()` config as a new `@theholocron/imports` config object
- Enables both `simple-import-sort/imports` and `simple-import-sort/exports` at `error` severity
- Adds the plugin as a required `peerDependency` (non-optional, since it's in `base` which all consumers use)
- Adds an explicit `Linter.Config[]` return type to `base()` to satisfy the tsdown/rolldown DTS emitter

## Why

Import ordering was previously unenforced, leading to inconsistent ordering across files and repos. Using `simple-import-sort` gives auto-fixable, deterministic ordering with zero configuration — builtins → externals → internals → relatives → type imports — without requiring consumers to configure anything.

Both rules are `error` so violations are caught in CI and surfaced in-editor via the ESLint language server.

## Consumer impact

Any repo consuming `@theholocron/eslint-config` will need to:
1. Install `eslint-plugin-simple-import-sort@^14` (new required peer dep)
2. Run `eslint --fix` once to auto-sort existing imports