### PR TITLE
docs: add holocron-config to repo layout in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ packages/
   browserslist-config/   — @theholocron/browserslist-config
   commitlint-config/     — @theholocron/commitlint-config
   eslint-config/         — @theholocron/eslint-config  (configs/ + bundles/)
+  holocron-config/       — @theholocron/holocron-config (presets/)
   lint-staged-config/    — @theholocron/lint-staged-config
   prettier-config/       — @theholocron/prettier-config
   semantic-release-config/ — @theholocron/semantic-release-config


### PR DESCRIPTION
## Summary

- Adds the missing `holocron-config/` entry to the repo layout package list in `AGENTS.md` — it was a fully-sourced package that had been omitted from the listing.

## Test plan

- [ ] `AGENTS.md` repo layout now matches the 13 packages listed in `README.md`