### PR TITLE
ci: use reusable deploy-docs workflow from theholocron/.github

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,45 +8,19 @@ on: # yamllint disable-line rule:truthy
       - packages/configs-docs/**
   workflow_dispatch:
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 permissions:
   contents: read
   pages: write
   id-token: write
 
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        name: Checkout repository
-
-      - uses: theholocron/.github/.github/actions/setup@main
-        name: Setup
-
-      - name: Build content packages
-        run: pnpm turbo build --filter=@theholocron/configs-docs
-
-      - name: Build docs site
-        run: pnpm --filter @theholocron/configs-site build
-
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
-        name: Upload pages artifact
-        with:
-          path: docs/dist
-
-  deploy:
-    name: Deploy
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
-        id: deployment
-        name: Deploy to GitHub Pages
+  deploy-docs:
+    name: Deploy Docs
+    uses: theholocron/.github/.github/workflows/deploy-docs.yml@main
+    with:
+      name: configs
+    secrets: inherit

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -27,7 +27,11 @@ export default defineConfig({
 		],
 		...repo,
 	},
-	workflows: [...workflows, { name: "release", with: { "run-build": true } }],
+	workflows: [
+		...workflows,
+		{ name: "release", with: { "run-build": true } },
+		{ name: "deploy-docs", with: { name: "configs" }, paths: ["packages/configs-docs/**"] },
+	],
 	providers,
 	agent: "claude",
 	skills: [

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -30,7 +30,11 @@ export default defineConfig({
 	workflows: [
 		...workflows,
 		{ name: "release", with: { "run-build": true } },
-		{ name: "deploy-docs", with: { name: "configs" }, paths: ["packages/configs-docs/**"] },
+		{
+			name: "deploy-docs",
+			with: { name: "configs" },
+			paths: ["packages/configs-docs/**"],
+		},
 	],
 	providers,
 	agent: "claude",


### PR DESCRIPTION
## Summary

- Replaces the inline `build` + `deploy` jobs in `deploy-docs.yml` with a thin caller that delegates to `theholocron/.github/.github/workflows/deploy-docs.yml@main`
- Passes `name: configs` so the reusable workflow can derive `@theholocron/configs-docs` and `@theholocron/configs-site` package names

## Test plan

- [ ] Merge `theholocron/.github#87` first
- [ ] Verify the Pages deploy triggers and succeeds on next push to `docs/**` or `packages/configs-docs/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)