### PR TITLE
refactor(docs): use createDocsCollections and defineConfig factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [7.8.1](https://github.com/theholocron/configs/compare/v7.8.0...v7.8.1) (2026-08-02)
+
 ## [7.8.0](https://github.com/theholocron/configs/compare/v7.7.0...v7.8.0) (2026-08-01)
 
 ## [7.7.0](https://github.com/theholocron/configs/compare/v7.6.2...v7.7.0) (2026-07-31)

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -1,41 +1,11 @@
-import { relative } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import starlight from "@astrojs/starlight";
-import configsConfig from "@theholocron/configs-docs";
 import { docsTheme } from "@theholocron/docs-theme";
-import { defineConfig } from "astro/config";
-
-// Starlight autogenerate matches filePaths relative to the Astro project root.
-// Our content lives outside docs/ so we compute the relative path so the
-// directory: value matches how the loader stores filePaths.
-const docsDir = fileURLToPath(new URL(".", import.meta.url));
-const contentDir = fileURLToPath(
-	new URL("../packages/configs-docs/content", import.meta.url),
-);
-const contentRelDir = relative(docsDir, contentDir);
+import { defineConfig } from "@theholocron/astro-config";
+import configsConfig from "@theholocron/configs-docs";
 
 export default defineConfig({
-	site: "https://theholocron.github.io",
-	base: "/configs",
-	integrations: [
-		starlight({
-			title: configsConfig.name,
-			plugins: [docsTheme()],
-			social: [
-				{
-					icon: "github",
-					label: "GitHub",
-					href: "https://github.com/theholocron/configs",
-				},
-			],
-			sidebar: [
-				{ label: "Overview", slug: "" },
-				{
-					label: "Packages",
-					items: [{ autogenerate: { directory: contentRelDir } }],
-				},
-			],
-		}),
-	],
+	docs: configsConfig,
+	importMetaUrl: import.meta.url,
+	starlight,
+	docsTheme,
 });

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -1,6 +1,6 @@
 import starlight from "@astrojs/starlight";
-import { docsTheme } from "@theholocron/docs-theme";
 import { defineConfig } from "@theholocron/astro-config";
+import { docsTheme } from "@theholocron/docs-theme";
 import configsConfig from "@theholocron/configs-docs";
 
 export default defineConfig({

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.5",
-    "@theholocron/astro-config": "workspace:*",
+    "@theholocron/astro-config": "^7.8.1",
     "@theholocron/configs-docs": "workspace:*",
     "@theholocron/docs-theme": "^1.3.0",
     "astro": "^7.1.5"

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,10 +11,10 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.5",
+    "@theholocron/astro-config": "workspace:*",
     "@theholocron/configs-docs": "workspace:*",
-    "@theholocron/docs-theme": "^1.1.0",
-    "astro": "^7.1.5",
-    "gray-matter": "^4.0.3"
+    "@theholocron/docs-theme": "^1.3.0",
+    "astro": "^7.1.5"
   },
   "devDependencies": {
     "@types/node": "^26.1.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "@astrojs/starlight": "^0.41.5",
     "@theholocron/astro-config": "^7.8.1",
     "@theholocron/configs-docs": "workspace:*",
-    "@theholocron/docs-theme": "^1.3.0",
+    "@theholocron/docs-theme": "^1.2.2",
     "astro": "^7.1.5"
   },
   "devDependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "@astrojs/starlight": "^0.41.5",
     "@theholocron/astro-config": "^7.8.1",
     "@theholocron/configs-docs": "workspace:*",
-    "@theholocron/docs-theme": "^1.2.2",
+    "@theholocron/docs-theme": "^1.3.0",
     "astro": "^7.1.5"
   },
   "devDependencies": {

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,4 +1,32 @@
-import configsConfig from "@theholocron/configs-docs";
-import { createDocsCollections } from "@theholocron/docs-theme/content";
+import { fileURLToPath } from "node:url";
 
-export const collections = createDocsCollections(configsConfig, import.meta.url);
+import { docsSchema } from "@astrojs/starlight/schema";
+import configsConfig from "@theholocron/configs-docs";
+import { createDocsLoader } from "@theholocron/docs-theme/loader";
+import { defineCollection } from "astro:content";
+
+const REPO_SLUG = configsConfig.slug;
+
+function localSlug(configSlug: string): string {
+	if (configSlug === REPO_SLUG) return "";
+	if (configSlug.startsWith(`${REPO_SLUG}/`))
+		return configSlug.slice(REPO_SLUG.length + 1);
+	return configSlug;
+}
+
+export const collections = {
+	docs: defineCollection({
+		loader: createDocsLoader([
+			{
+				dir: fileURLToPath(
+					new URL(
+						"../../packages/configs-docs/content",
+						import.meta.url,
+					),
+				),
+				slug: localSlug(configsConfig.slug),
+			},
+		]),
+		schema: docsSchema(),
+	}),
+};

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,4 +1,7 @@
 import configsConfig from "@theholocron/configs-docs";
 import { createDocsCollections } from "@theholocron/docs-theme/content";
 
-export const collections = createDocsCollections(configsConfig, import.meta.url);
+export const collections = createDocsCollections(
+	configsConfig,
+	import.meta.url,
+);

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,7 +1,4 @@
 import configsConfig from "@theholocron/configs-docs";
 import { createDocsCollections } from "@theholocron/docs-theme/content";
 
-export const collections = createDocsCollections(
-	configsConfig,
-	import.meta.url,
-);
+export const collections = createDocsCollections(configsConfig, import.meta.url);

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,32 +1,7 @@
-import { fileURLToPath } from "node:url";
-
-import { docsSchema } from "@astrojs/starlight/schema";
 import configsConfig from "@theholocron/configs-docs";
-import { createDocsLoader } from "@theholocron/docs-theme/loader";
-import { defineCollection } from "astro:content";
+import { createDocsCollections } from "@theholocron/docs-theme/content";
 
-const REPO_SLUG = configsConfig.slug;
-
-function localSlug(configSlug: string): string {
-	if (configSlug === REPO_SLUG) return "";
-	if (configSlug.startsWith(`${REPO_SLUG}/`))
-		return configSlug.slice(REPO_SLUG.length + 1);
-	return configSlug;
-}
-
-export const collections = {
-	docs: defineCollection({
-		loader: createDocsLoader([
-			{
-				dir: fileURLToPath(
-					new URL(
-						"../../packages/configs-docs/content",
-						import.meta.url,
-					),
-				),
-				slug: localSlug(configsConfig.slug),
-			},
-		]),
-		schema: docsSchema(),
-	}),
-};
+export const collections = createDocsCollections(
+	configsConfig,
+	import.meta.url,
+);

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,32 +1,4 @@
-import { fileURLToPath } from "node:url";
-
-import { docsSchema } from "@astrojs/starlight/schema";
 import configsConfig from "@theholocron/configs-docs";
-import { createDocsLoader } from "@theholocron/docs-theme/loader";
-import { defineCollection } from "astro:content";
+import { createDocsCollections } from "@theholocron/docs-theme/content";
 
-const REPO_SLUG = configsConfig.slug;
-
-function localSlug(configSlug: string): string {
-	if (configSlug === REPO_SLUG) return "";
-	if (configSlug.startsWith(`${REPO_SLUG}/`))
-		return configSlug.slice(REPO_SLUG.length + 1);
-	return configSlug;
-}
-
-export const collections = {
-	docs: defineCollection({
-		loader: createDocsLoader([
-			{
-				dir: fileURLToPath(
-					new URL(
-						"../../packages/configs-docs/content",
-						import.meta.url,
-					),
-				),
-				slug: localSlug(configsConfig.slug),
-			},
-		]),
-		schema: docsSchema(),
-	}),
-};
+export const collections = createDocsCollections(configsConfig, import.meta.url);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/configs",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "private": true,
   "description": "Shared configuration files.",
   "keywords": [

--- a/packages/astro-config/README.md
+++ b/packages/astro-config/README.md
@@ -10,30 +10,38 @@ npm install --save-dev @theholocron/astro-config
 
 ## Usage
 
-Replace `astro/config`'s `defineConfig` with this package's `defineConfig` and pass a `docs` config object and `importMetaUrl`:
+Pass `starlight` and `docsTheme` from your own imports alongside the docs config. This keeps Astro's module loader in control of those framework imports:
 
 ```ts
 // astro.config.ts
+import starlight from "@astrojs/starlight";
+import { docsTheme } from "@theholocron/docs-theme";
 import { defineConfig } from "@theholocron/astro-config";
 import clientsConfig from "@theholocron/clients-docs";
 
 export default defineConfig({
   docs: clientsConfig,
   importMetaUrl: import.meta.url,
+  starlight,
+  docsTheme,
 });
 ```
 
 ### Custom sidebar label
 
-By default the sidebar group label is derived from `docs.sidebar[1].label`. Override it when the group label in the docs config differs from what the site should show:
+By default the sidebar group label is derived from `docs.sidebar[1].label`. Override it when the label differs:
 
 ```ts
+import starlight from "@astrojs/starlight";
+import { docsTheme } from "@theholocron/docs-theme";
 import { defineConfig } from "@theholocron/astro-config";
 import holocronConfig from "@theholocron/holocron-docs";
 
 export default defineConfig({
   docs: holocronConfig,
   importMetaUrl: import.meta.url,
+  starlight,
+  docsTheme,
   sidebarLabel: "Reference",
 });
 ```

--- a/packages/astro-config/index.test.ts
+++ b/packages/astro-config/index.test.ts
@@ -3,14 +3,20 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("astro/config", () => ({
 	defineConfig: vi.fn((config: unknown) => config),
 }));
-vi.mock("@astrojs/starlight", () => ({
-	default: vi.fn((config: unknown) => ({ name: "starlight", config })),
-}));
-vi.mock("@theholocron/docs-theme", () => ({
-	docsTheme: vi.fn(() => ({ name: "@theholocron/docs-theme" })),
-}));
+
+import type starlight from "@astrojs/starlight";
+import type { docsTheme } from "@theholocron/docs-theme";
 
 import { defineConfig } from "./index.js";
+
+const mockStarlight = vi.fn((config: unknown) => ({
+	name: "starlight",
+	config,
+})) as unknown as typeof starlight;
+
+const mockDocsTheme = vi.fn(() => ({
+	name: "@theholocron/docs-theme",
+})) as unknown as typeof docsTheme;
 
 const mockDocs = {
 	slug: "clients",
@@ -21,22 +27,21 @@ const mockDocs = {
 	],
 };
 
+const baseInput = {
+	docs: mockDocs,
+	importMetaUrl: import.meta.url,
+	starlight: mockStarlight,
+	docsTheme: mockDocsTheme,
+};
+
 describe("defineConfig", () => {
 	it("sets base from the docs slug", () => {
-		const config = defineConfig({
-			docs: mockDocs,
-			importMetaUrl: import.meta.url,
-		}) as {
-			base: string;
-		};
+		const config = defineConfig(baseInput) as { base: string };
 		expect(config.base).toBe("/clients");
 	});
 
 	it("derives sidebar label from sidebar[1].label when it is a group", () => {
-		const config = defineConfig({
-			docs: mockDocs,
-			importMetaUrl: import.meta.url,
-		}) as unknown as {
+		const config = defineConfig(baseInput) as unknown as {
 			integrations: Array<{
 				config: { sidebar: Array<{ label: string }> };
 			}>;
@@ -46,8 +51,7 @@ describe("defineConfig", () => {
 
 	it("accepts a sidebarLabel override", () => {
 		const config = defineConfig({
-			docs: mockDocs,
-			importMetaUrl: import.meta.url,
+			...baseInput,
 			sidebarLabel: "Reference",
 		}) as unknown as {
 			integrations: Array<{
@@ -60,16 +64,15 @@ describe("defineConfig", () => {
 	});
 
 	it("falls back to 'Contents' when sidebar[1] is a link not a group", () => {
-		const linkDocs = {
-			...mockDocs,
-			sidebar: [
-				{ label: "Overview", slug: "clients" },
-				{ label: "Getting Started", slug: "clients/start" },
-			],
-		};
 		const config = defineConfig({
-			docs: linkDocs,
-			importMetaUrl: import.meta.url,
+			...baseInput,
+			docs: {
+				...mockDocs,
+				sidebar: [
+					{ label: "Overview", slug: "clients" },
+					{ label: "Getting Started", slug: "clients/start" },
+				],
+			},
 		}) as unknown as {
 			integrations: Array<{
 				config: { sidebar: Array<{ label: string }> };

--- a/packages/astro-config/index.ts
+++ b/packages/astro-config/index.ts
@@ -1,8 +1,8 @@
 import { relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import starlight from "@astrojs/starlight";
-import { docsTheme } from "@theholocron/docs-theme";
+import type starlight from "@astrojs/starlight";
+import type { docsTheme } from "@theholocron/docs-theme";
 import { defineConfig as astroDefineConfig } from "astro/config";
 
 interface SidebarGroup {
@@ -21,12 +21,16 @@ export interface DocsConfig {
 export interface DocsConfigInput {
 	docs: DocsConfig;
 	importMetaUrl: string;
+	starlight: typeof starlight;
+	docsTheme: typeof docsTheme;
 	sidebarLabel?: string;
 }
 
 export function defineConfig({
 	docs,
 	importMetaUrl,
+	starlight,
+	docsTheme,
 	sidebarLabel,
 }: DocsConfigInput) {
 	const docsDir = fileURLToPath(new URL(".", importMetaUrl));

--- a/packages/astro-config/package.json
+++ b/packages/astro-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/astro-config",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "Astro configuration factory for theholocron docs sites.",
   "keywords": [
     "astro",

--- a/packages/astro-config/package.json
+++ b/packages/astro-config/package.json
@@ -46,8 +46,6 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@astrojs/starlight": ">=0.30.0",
-    "@theholocron/docs-theme": ">=1.2.2",
     "astro": ">=5.0.0"
   },
   "engines": {

--- a/packages/astro-config/tsdown.config.ts
+++ b/packages/astro-config/tsdown.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
 	fixedExtension: false,
 	dts: true,
 	clean: true,
+	external: ["@astrojs/starlight", "@theholocron/docs-theme"],
 });

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/browserslist-config",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "A Browserslist configuration for all browsers and devices supported in the Galaxy.",
   "homepage": "https://github.com/theholocron/configs/tree/main/packages/browserslist-config#readme",
   "bugs": "https://github.com/theholocron/configs/issues",

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/commitlint-config",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "A CommitLint configuration for writing well-formatted and consistent Git commits.",
   "homepage": "https://github.com/theholocron/configs/tree/main/packages/commitlint-config#readme",
   "bugs": "https://github.com/theholocron/configs/issues",

--- a/packages/configs-docs/package.json
+++ b/packages/configs-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/configs-docs",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "Documentation content for the @theholocron/configs monorepo",
   "homepage": "https://github.com/theholocron/configs/tree/main/packages/configs-docs#readme",
   "bugs": "https://github.com/theholocron/configs/issues",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/eslint-config",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "A ESLint configuration for writing well-formed Javascript within the Galaxy.",
   "homepage": "https://github.com/theholocron/configs/tree/main/packages/eslint-config#readme",
   "bugs": "https://github.com/theholocron/configs/issues",

--- a/packages/holocron-config/package.json
+++ b/packages/holocron-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/holocron-config",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "Shareable holocron configuration presets for theholocron repositories.",
   "homepage": "https://github.com/theholocron/configs/tree/main/packages/holocron-config#readme",
   "bugs": "https://github.com/theholocron/configs/issues",

--- a/packages/lint-staged-config/package.json
+++ b/packages/lint-staged-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/lint-staged-config",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "A Lint Staged configuration for linting code that has been staged in Git within the Galaxy.",
   "homepage": "https://github.com/theholocron/configs/tree/main/packages/lint-staged-config#readme",
   "bugs": "https://github.com/theholocron/configs/issues",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/prettier-config",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "A Prettier configuration for formatting libraries in the Galaxy.",
   "homepage": "https://github.com/theholocron/configs/tree/main/packages/prettier-config#readme",
   "bugs": "https://github.com/theholocron/configs/issues",

--- a/packages/semantic-release-config/package.json
+++ b/packages/semantic-release-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/semantic-release-config",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "A semantic-release configuration for automated versioning and publishing.",
   "homepage": "https://github.com/theholocron/configs/tree/main/packages/semantic-release-config#readme",
   "bugs": "https://github.com/theholocron/configs/issues",

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/storybook-config",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "A Storybook configuration for writing tested components within the Galaxy.",
   "homepage": "https://github.com/theholocron/configs/tree/main/packages/storybook-config#readme",
   "bugs": "https://github.com/theholocron/configs/issues",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/stylelint-config",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "A StyleLint configuration for writing well-formed CSS within the Galaxy.",
   "homepage": "https://github.com/theholocron/configs/tree/main/packages/stylelint-config#readme",
   "bugs": "https://github.com/theholocron/configs/issues",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/tsconfig",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "TypeScript base configurations for theholocron projects.",
   "homepage": "https://github.com/theholocron/configs/tree/main/packages/tsconfig#readme",
   "bugs": "https://github.com/theholocron/configs/issues",

--- a/packages/tsdown-config/package.json
+++ b/packages/tsdown-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/tsdown-config",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "Shared tsdown configurations for @theholocron packages.",
   "homepage": "https://github.com/theholocron/configs/tree/main/packages/tsdown-config#readme",
   "bugs": "https://github.com/theholocron/configs/issues",

--- a/packages/vite-config/package.json
+++ b/packages/vite-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/vite-config",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "Vite configuration presets for libraries, React apps, and Node tools within the Galaxy.",
   "homepage": "https://github.com/theholocron/configs/tree/main/packages/vite-config#readme",
   "bugs": "https://github.com/theholocron/configs/issues",

--- a/packages/vitest-config/package.json
+++ b/packages/vitest-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theholocron/vitest-config",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "Vitest configuration presets for libraries, React apps, and Storybook within the Galaxy.",
   "homepage": "https://github.com/theholocron/configs/tree/main/packages/vitest-config#readme",
   "bugs": "https://github.com/theholocron/configs/issues",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,18 +110,18 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.41.5
         version: 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
+      '@theholocron/astro-config':
+        specifier: workspace:*
+        version: link:../packages/astro-config
       '@theholocron/configs-docs':
         specifier: workspace:*
         version: link:../packages/configs-docs
       '@theholocron/docs-theme':
-        specifier: ^1.1.0
-        version: 1.1.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^1.3.0
+        version: 1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
       astro:
         specifier: ^7.1.5
         version: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)
-      gray-matter:
-        specifier: ^4.0.3
-        version: 4.0.3
     devDependencies:
       '@types/node':
         specifier: ^26.1.2
@@ -2925,15 +2925,15 @@ packages:
     resolution: {integrity: sha512-/lusysF8FN/qtLnurldqy6SSnQDw9gdjcvi8qGeKlOS4z2VK/qY1l32DE6pEp0krRz4iknPf6bxRh4W2pxjU7Q==}
     hasBin: true
 
-  '@theholocron/docs-theme@1.1.0':
-    resolution: {integrity: sha512-UI9NvBg5L5v3HRQ6kVmT4Pjy8SQ2Du+8b1AslERF/fTtngxapl68NEPCcBc+YwVsg8xB87I6t3UMTdDaqAiAzQ==}
+  '@theholocron/docs-theme@1.2.2':
+    resolution: {integrity: sha512-fEGxPR61wZgz1aC8GZI9t38W3+s3z0dmLrDOwmqkHRhXxSASmhytXhNqWv5yCQ0KDy9vk8uPRHoTvZKxjOAy9Q==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@astrojs/starlight': '>=0.30.0'
       astro: '>=5.0.0'
 
-  '@theholocron/docs-theme@1.2.2':
-    resolution: {integrity: sha512-fEGxPR61wZgz1aC8GZI9t38W3+s3z0dmLrDOwmqkHRhXxSASmhytXhNqWv5yCQ0KDy9vk8uPRHoTvZKxjOAy9Q==}
+  '@theholocron/docs-theme@1.3.0':
+    resolution: {integrity: sha512-F6+j8kPySJ01cxmRlRxY/zaPaP106LsmehMQnDUHWTYfVaIWm9GfVp6xa2Jaix2tESujIXUSMhTyLRo1Z9bqGA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@astrojs/starlight': '>=0.30.0'
@@ -10760,13 +10760,13 @@ snapshots:
       - supports-color
       - vitest
 
-  '@theholocron/docs-theme@1.1.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
+  '@theholocron/docs-theme@1.2.2(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@astrojs/starlight': 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
       astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)
       gray-matter: 4.0.3
 
-  '@theholocron/docs-theme@1.2.2(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
+  '@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@astrojs/starlight': 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
       astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,13 +111,13 @@ importers:
         specifier: ^0.41.5
         version: 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
       '@theholocron/astro-config':
-        specifier: workspace:*
-        version: link:../packages/astro-config
+        specifier: ^7.8.1
+        version: 7.8.1(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
       '@theholocron/configs-docs':
         specifier: workspace:*
         version: link:../packages/configs-docs
       '@theholocron/docs-theme':
-        specifier: ^1.3.0
+        specifier: ^1.2.2
         version: 1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
       astro:
         specifier: ^7.1.5
@@ -2920,6 +2920,12 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
+
+  '@theholocron/astro-config@7.8.1':
+    resolution: {integrity: sha512-ML8EESizp2X7uTnw2y2Xg+rtgm7GLnrFIPfVPXc3ZK2AtNmwSwNtycKJleKefy4Vwn+iUdZgjK1bbZuPV8j0eA==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      astro: '>=5.0.0'
 
   '@theholocron/cli@3.4.0':
     resolution: {integrity: sha512-/lusysF8FN/qtLnurldqy6SSnQDw9gdjcvi8qGeKlOS4z2VK/qY1l32DE6pEp0krRz4iknPf6bxRh4W2pxjU7Q==}
@@ -10743,6 +10749,10 @@ snapshots:
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
+
+  '@theholocron/astro-config@7.8.1(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)
 
   '@theholocron/cli@3.4.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(vitest@4.1.10)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
         specifier: workspace:*
         version: link:../packages/configs-docs
       '@theholocron/docs-theme':
-        specifier: ^1.2.2
+        specifier: ^1.3.0
         version: 1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
       astro:
         specifier: ^7.1.5
@@ -227,7 +227,7 @@ importers:
         version: 7.37.5(eslint@10.7.0(jiti@2.6.1))
       eslint-plugin-storybook:
         specifier: ^10
-        version: 10.5.0(eslint@10.7.0(jiti@2.6.1))(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3)
+        version: 10.5.0(eslint@10.7.0(jiti@2.6.1))(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3)
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.0
@@ -258,7 +258,7 @@ importers:
         version: 8.65.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/holocron-config:
     devDependencies:
@@ -555,7 +555,7 @@ importers:
     dependencies:
       '@storybook/addon-vitest':
         specifier: ^9
-        version: 9.1.20(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(vitest@4.1.10)
+        version: 9.1.20(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(vitest@4.1.10)
       '@testing-library/react':
         specifier: ^16
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -564,7 +564,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/browser':
         specifier: ^4
-        version: 4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+        version: 4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
       jsdom:
         specifier: ^26
         version: 26.1.0
@@ -586,7 +586,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
@@ -10550,21 +10550,6 @@ snapshots:
       storybook: 9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
       ts-dedent: 2.3.0
 
-  '@storybook/addon-vitest@9.1.20(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(vitest@4.1.10)':
-    dependencies:
-      '@storybook/global': 5.0.0
-      '@storybook/icons': 1.6.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      prompts: 2.4.2
-      storybook: 9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
-      ts-dedent: 2.3.0
-    optionalDependencies:
-      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/runner': 4.1.10
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - react
-      - react-dom
-
   '@storybook/addon-vitest@9.1.20(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(vitest@4.1.10)':
     dependencies:
       '@storybook/global': 5.0.0
@@ -11110,23 +11095,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':
-    dependencies:
-      '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
-      '@vitest/utils': 4.1.10
-      magic-string: 0.30.21
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
-      ws: 8.21.1
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-
   '@vitest/browser@4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
@@ -11143,7 +11111,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)':
     dependencies:
@@ -11169,7 +11136,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -12597,12 +12564,12 @@ snapshots:
     dependencies:
       eslint: 10.7.0(jiti@2.6.1)
 
-  eslint-plugin-storybook@10.5.0(eslint@10.7.0(jiti@2.6.1))(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3):
+  eslint-plugin-storybook@10.5.0(eslint@10.7.0(jiti@2.6.1))(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/utils': 8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 10.7.0(jiti@2.6.1)
-      storybook: 9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+      storybook: 9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
       - typescript

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,7 +227,7 @@ importers:
         version: 7.37.5(eslint@10.7.0(jiti@2.6.1))
       eslint-plugin-storybook:
         specifier: ^10
-        version: 10.5.0(eslint@10.7.0(jiti@2.6.1))(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3)
+        version: 10.5.0(eslint@10.7.0(jiti@2.6.1))(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3)
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.0
@@ -258,7 +258,7 @@ importers:
         version: 8.65.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/holocron-config:
     devDependencies:
@@ -555,7 +555,7 @@ importers:
     dependencies:
       '@storybook/addon-vitest':
         specifier: ^9
-        version: 9.1.20(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(vitest@4.1.10)
+        version: 9.1.20(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(vitest@4.1.10)
       '@testing-library/react':
         specifier: ^16
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -564,7 +564,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/browser':
         specifier: ^4
-        version: 4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+        version: 4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
       jsdom:
         specifier: ^26
         version: 26.1.0
@@ -586,7 +586,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
@@ -6905,8 +6905,8 @@ packages:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
-  recast@0.23.12:
-    resolution: {integrity: sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA==}
+  recast@0.23.19:
+    resolution: {integrity: sha512-T98lym7kH+pnZmRaD8yDRdaNqyUbwnbEBx0MuchrzMFOEMray4AO3ZJoTUZ5r78Ao78X/OhzW0DL8GB85w/I2w==}
     engines: {node: '>= 4'}
 
   recma-build-jsx@1.0.0:
@@ -10550,6 +10550,21 @@ snapshots:
       storybook: 9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
       ts-dedent: 2.3.0
 
+  '@storybook/addon-vitest@9.1.20(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(vitest@4.1.10)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 1.6.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      prompts: 2.4.2
+      storybook: 9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+      ts-dedent: 2.3.0
+    optionalDependencies:
+      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/runner': 4.1.10
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@storybook/addon-vitest@9.1.20(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(vitest@4.1.10)':
     dependencies:
       '@storybook/global': 5.0.0
@@ -11095,6 +11110,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/browser@4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
   '@vitest/browser@4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
@@ -11111,6 +11143,7 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
   '@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)':
     dependencies:
@@ -11136,7 +11169,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -12564,12 +12597,12 @@ snapshots:
     dependencies:
       eslint: 10.7.0(jiti@2.6.1)
 
-  eslint-plugin-storybook@10.5.0(eslint@10.7.0(jiti@2.6.1))(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3):
+  eslint-plugin-storybook@10.5.0(eslint@10.7.0(jiti@2.6.1))(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/utils': 8.63.0(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 10.7.0(jiti@2.6.1)
-      storybook: 9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+      storybook: 9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -15661,7 +15694,7 @@ snapshots:
 
   readdirp@5.0.0: {}
 
-  recast@0.23.12:
+  recast@0.23.19:
     dependencies:
       ast-types: 0.16.1
       esprima: 4.0.1
@@ -16412,7 +16445,7 @@ snapshots:
       better-opn: 3.0.2
       esbuild: 0.25.12
       esbuild-register: 3.6.0(esbuild@0.25.12)
-      recast: 0.23.12
+      recast: 0.23.19
       semver: 7.8.5
       ws: 8.21.1
     optionalDependencies:
@@ -16436,7 +16469,7 @@ snapshots:
       better-opn: 3.0.2
       esbuild: 0.25.12
       esbuild-register: 3.6.0(esbuild@0.25.12)
-      recast: 0.23.12
+      recast: 0.23.19
       semver: 7.8.5
       ws: 8.21.1
     optionalDependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "tasks": {
-    "build": { "outputs": ["dist/**"] },
+    "build": { "dependsOn": ["^build"], "outputs": ["dist/**"] },
     "lint": { "dependsOn": ["^build"] },
     "test": { "dependsOn": ["build", "^build"] },
     "typecheck": { "dependsOn": ["^build"] }


### PR DESCRIPTION
## Summary

- Replaces \`astro.config.ts\` boilerplate with \`defineConfig\` from \`@theholocron/astro-config\`
- Replaces \`content.config.ts\` boilerplate with \`createDocsCollections\` from \`@theholocron/docs-theme/content\`
- Removes direct \`gray-matter\` dependency (now internal to docs-theme)
- Bumps \`@theholocron/docs-theme\` to \`^1.3.0\` (required for the \`/content\` export)

## Note

CI will go green once [theholocron/themes#26](https://github.com/theholocron/themes/pull/26) merges and \`@theholocron/docs-theme@1.3.0\` publishes.

## Test plan

- [ ] \`astro build\` succeeds
- [ ] Docs site renders correctly