### PR TITLE
fix(astro-config): use import type + externals, accept framework fns as typed inputs

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -1,4 +1,11 @@
+import starlight from "@astrojs/starlight";
+import { docsTheme } from "@theholocron/docs-theme";
 import { defineConfig } from "@theholocron/astro-config";
 import configsConfig from "@theholocron/configs-docs";
 
-export default defineConfig({ docs: configsConfig, importMetaUrl: import.meta.url });
+export default defineConfig({
+	docs: configsConfig,
+	importMetaUrl: import.meta.url,
+	starlight,
+	docsTheme,
+});

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -1,41 +1,4 @@
-import { relative } from "node:path";
-import { fileURLToPath } from "node:url";
-
-import starlight from "@astrojs/starlight";
+import { defineConfig } from "@theholocron/astro-config";
 import configsConfig from "@theholocron/configs-docs";
-import { docsTheme } from "@theholocron/docs-theme";
-import { defineConfig } from "astro/config";
 
-// Starlight autogenerate matches filePaths relative to the Astro project root.
-// Our content lives outside docs/ so we compute the relative path so the
-// directory: value matches how the loader stores filePaths.
-const docsDir = fileURLToPath(new URL(".", import.meta.url));
-const contentDir = fileURLToPath(
-	new URL("../packages/configs-docs/content", import.meta.url),
-);
-const contentRelDir = relative(docsDir, contentDir);
-
-export default defineConfig({
-	site: "https://theholocron.github.io",
-	base: "/configs",
-	integrations: [
-		starlight({
-			title: configsConfig.name,
-			plugins: [docsTheme()],
-			social: [
-				{
-					icon: "github",
-					label: "GitHub",
-					href: "https://github.com/theholocron/configs",
-				},
-			],
-			sidebar: [
-				{ label: "Overview", slug: "" },
-				{
-					label: "Packages",
-					items: [{ autogenerate: { directory: contentRelDir } }],
-				},
-			],
-		}),
-	],
-});
+export default defineConfig({ docs: configsConfig, importMetaUrl: import.meta.url });

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.5",
-    "@theholocron/astro-config": "^7.8.0",
+    "@theholocron/astro-config": "workspace:*",
     "@theholocron/configs-docs": "workspace:*",
     "@theholocron/docs-theme": "^1.3.0",
     "astro": "^7.1.5"

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "@astrojs/starlight": "^0.41.5",
     "@theholocron/astro-config": "^7.8.0",
     "@theholocron/configs-docs": "workspace:*",
-    "@theholocron/docs-theme": "^1.3.0",
+    "@theholocron/docs-theme": "^1.2.2",
     "astro": "^7.1.5"
   },
   "devDependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,10 +11,10 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.5",
+    "@theholocron/astro-config": "^7.8.0",
     "@theholocron/configs-docs": "workspace:*",
-    "@theholocron/docs-theme": "^1.1.0",
-    "astro": "^7.1.5",
-    "gray-matter": "^4.0.3"
+    "@theholocron/docs-theme": "^1.3.0",
+    "astro": "^7.1.5"
   },
   "devDependencies": {
     "@types/node": "^26.1.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "@astrojs/starlight": "^0.41.5",
     "@theholocron/astro-config": "^7.8.0",
     "@theholocron/configs-docs": "workspace:*",
-    "@theholocron/docs-theme": "^1.2.2",
+    "@theholocron/docs-theme": "^1.3.0",
     "astro": "^7.1.5"
   },
   "devDependencies": {

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,4 +1,32 @@
-import configsConfig from "@theholocron/configs-docs";
-import { createDocsCollections } from "@theholocron/docs-theme/content";
+import { fileURLToPath } from "node:url";
 
-export const collections = createDocsCollections(configsConfig, import.meta.url);
+import { docsSchema } from "@astrojs/starlight/schema";
+import configsConfig from "@theholocron/configs-docs";
+import { createDocsLoader } from "@theholocron/docs-theme/loader";
+import { defineCollection } from "astro:content";
+
+const REPO_SLUG = configsConfig.slug;
+
+function localSlug(configSlug: string): string {
+	if (configSlug === REPO_SLUG) return "";
+	if (configSlug.startsWith(`${REPO_SLUG}/`))
+		return configSlug.slice(REPO_SLUG.length + 1);
+	return configSlug;
+}
+
+export const collections = {
+	docs: defineCollection({
+		loader: createDocsLoader([
+			{
+				dir: fileURLToPath(
+					new URL(
+						"../../packages/configs-docs/content",
+						import.meta.url,
+					),
+				),
+				slug: localSlug(configsConfig.slug),
+			},
+		]),
+		schema: docsSchema(),
+	}),
+};

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,4 +1,7 @@
 import configsConfig from "@theholocron/configs-docs";
 import { createDocsCollections } from "@theholocron/docs-theme/content";
 
-export const collections = createDocsCollections(configsConfig, import.meta.url);
+export const collections = createDocsCollections(
+	configsConfig,
+	import.meta.url,
+);

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,32 +1,4 @@
-import { fileURLToPath } from "node:url";
-
-import { docsSchema } from "@astrojs/starlight/schema";
 import configsConfig from "@theholocron/configs-docs";
-import { createDocsLoader } from "@theholocron/docs-theme/loader";
-import { defineCollection } from "astro:content";
+import { createDocsCollections } from "@theholocron/docs-theme/content";
 
-const REPO_SLUG = configsConfig.slug;
-
-function localSlug(configSlug: string): string {
-	if (configSlug === REPO_SLUG) return "";
-	if (configSlug.startsWith(`${REPO_SLUG}/`))
-		return configSlug.slice(REPO_SLUG.length + 1);
-	return configSlug;
-}
-
-export const collections = {
-	docs: defineCollection({
-		loader: createDocsLoader([
-			{
-				dir: fileURLToPath(
-					new URL(
-						"../../packages/configs-docs/content",
-						import.meta.url,
-					),
-				),
-				slug: localSlug(configsConfig.slug),
-			},
-		]),
-		schema: docsSchema(),
-	}),
-};
+export const collections = createDocsCollections(configsConfig, import.meta.url);

--- a/packages/astro-config/README.md
+++ b/packages/astro-config/README.md
@@ -10,30 +10,38 @@ npm install --save-dev @theholocron/astro-config
 
 ## Usage
 
-Replace `astro/config`'s `defineConfig` with this package's `defineConfig` and pass a `docs` config object and `importMetaUrl`:
+Pass `starlight` and `docsTheme` from your own imports alongside the docs config. This keeps Astro's module loader in control of those framework imports:
 
 ```ts
 // astro.config.ts
+import starlight from "@astrojs/starlight";
+import { docsTheme } from "@theholocron/docs-theme";
 import { defineConfig } from "@theholocron/astro-config";
 import clientsConfig from "@theholocron/clients-docs";
 
 export default defineConfig({
   docs: clientsConfig,
   importMetaUrl: import.meta.url,
+  starlight,
+  docsTheme,
 });
 ```
 
 ### Custom sidebar label
 
-By default the sidebar group label is derived from `docs.sidebar[1].label`. Override it when the group label in the docs config differs from what the site should show:
+By default the sidebar group label is derived from `docs.sidebar[1].label`. Override it when the label differs:
 
 ```ts
+import starlight from "@astrojs/starlight";
+import { docsTheme } from "@theholocron/docs-theme";
 import { defineConfig } from "@theholocron/astro-config";
 import holocronConfig from "@theholocron/holocron-docs";
 
 export default defineConfig({
   docs: holocronConfig,
   importMetaUrl: import.meta.url,
+  starlight,
+  docsTheme,
   sidebarLabel: "Reference",
 });
 ```

--- a/packages/astro-config/index.test.ts
+++ b/packages/astro-config/index.test.ts
@@ -9,13 +9,14 @@ import type { docsTheme } from "@theholocron/docs-theme";
 
 import { defineConfig } from "./index.js";
 
-const mockStarlight = vi.fn(
-	(config: unknown) => ({ name: "starlight", config }),
-) as unknown as typeof starlight;
+const mockStarlight = vi.fn((config: unknown) => ({
+	name: "starlight",
+	config,
+})) as unknown as typeof starlight;
 
-const mockDocsTheme = vi.fn(
-	() => ({ name: "@theholocron/docs-theme" }),
-) as unknown as typeof docsTheme;
+const mockDocsTheme = vi.fn(() => ({
+	name: "@theholocron/docs-theme",
+})) as unknown as typeof docsTheme;
 
 const mockDocs = {
 	slug: "clients",
@@ -57,7 +58,9 @@ describe("defineConfig", () => {
 				config: { sidebar: Array<{ label: string }> };
 			}>;
 		};
-		expect(config.integrations[0].config.sidebar[1].label).toBe("Reference");
+		expect(config.integrations[0].config.sidebar[1].label).toBe(
+			"Reference",
+		);
 	});
 
 	it("falls back to 'Contents' when sidebar[1] is a link not a group", () => {

--- a/packages/astro-config/index.test.ts
+++ b/packages/astro-config/index.test.ts
@@ -4,10 +4,18 @@ vi.mock("astro/config", () => ({
 	defineConfig: vi.fn((config: unknown) => config),
 }));
 
+import type starlight from "@astrojs/starlight";
+import type { docsTheme } from "@theholocron/docs-theme";
+
 import { defineConfig } from "./index.js";
 
-const mockStarlight = vi.fn((config: unknown) => ({ name: "starlight", config }));
-const mockDocsTheme = vi.fn(() => ({ name: "@theholocron/docs-theme" }));
+const mockStarlight = vi.fn(
+	(config: unknown) => ({ name: "starlight", config }),
+) as unknown as typeof starlight;
+
+const mockDocsTheme = vi.fn(
+	() => ({ name: "@theholocron/docs-theme" }),
+) as unknown as typeof docsTheme;
 
 const mockDocs = {
 	slug: "clients",

--- a/packages/astro-config/index.test.ts
+++ b/packages/astro-config/index.test.ts
@@ -3,14 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("astro/config", () => ({
 	defineConfig: vi.fn((config: unknown) => config),
 }));
-vi.mock("@astrojs/starlight", () => ({
-	default: vi.fn((config: unknown) => ({ name: "starlight", config })),
-}));
-vi.mock("@theholocron/docs-theme", () => ({
-	docsTheme: vi.fn(() => ({ name: "@theholocron/docs-theme" })),
-}));
 
 import { defineConfig } from "./index.js";
+
+const mockStarlight = vi.fn((config: unknown) => ({ name: "starlight", config }));
+const mockDocsTheme = vi.fn(() => ({ name: "@theholocron/docs-theme" }));
 
 const mockDocs = {
 	slug: "clients",
@@ -21,22 +18,21 @@ const mockDocs = {
 	],
 };
 
+const baseInput = {
+	docs: mockDocs,
+	importMetaUrl: import.meta.url,
+	starlight: mockStarlight,
+	docsTheme: mockDocsTheme,
+};
+
 describe("defineConfig", () => {
 	it("sets base from the docs slug", () => {
-		const config = defineConfig({
-			docs: mockDocs,
-			importMetaUrl: import.meta.url,
-		}) as {
-			base: string;
-		};
+		const config = defineConfig(baseInput) as { base: string };
 		expect(config.base).toBe("/clients");
 	});
 
 	it("derives sidebar label from sidebar[1].label when it is a group", () => {
-		const config = defineConfig({
-			docs: mockDocs,
-			importMetaUrl: import.meta.url,
-		}) as unknown as {
+		const config = defineConfig(baseInput) as unknown as {
 			integrations: Array<{
 				config: { sidebar: Array<{ label: string }> };
 			}>;
@@ -46,30 +42,26 @@ describe("defineConfig", () => {
 
 	it("accepts a sidebarLabel override", () => {
 		const config = defineConfig({
-			docs: mockDocs,
-			importMetaUrl: import.meta.url,
+			...baseInput,
 			sidebarLabel: "Reference",
 		}) as unknown as {
 			integrations: Array<{
 				config: { sidebar: Array<{ label: string }> };
 			}>;
 		};
-		expect(config.integrations[0].config.sidebar[1].label).toBe(
-			"Reference",
-		);
+		expect(config.integrations[0].config.sidebar[1].label).toBe("Reference");
 	});
 
 	it("falls back to 'Contents' when sidebar[1] is a link not a group", () => {
-		const linkDocs = {
-			...mockDocs,
-			sidebar: [
-				{ label: "Overview", slug: "clients" },
-				{ label: "Getting Started", slug: "clients/start" },
-			],
-		};
 		const config = defineConfig({
-			docs: linkDocs,
-			importMetaUrl: import.meta.url,
+			...baseInput,
+			docs: {
+				...mockDocs,
+				sidebar: [
+					{ label: "Overview", slug: "clients" },
+					{ label: "Getting Started", slug: "clients/start" },
+				],
+			},
 		}) as unknown as {
 			integrations: Array<{
 				config: { sidebar: Array<{ label: string }> };

--- a/packages/astro-config/index.ts
+++ b/packages/astro-config/index.ts
@@ -1,8 +1,6 @@
 import { relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import starlight from "@astrojs/starlight";
-import { docsTheme } from "@theholocron/docs-theme";
 import { defineConfig as astroDefineConfig } from "astro/config";
 
 interface SidebarGroup {
@@ -21,12 +19,18 @@ export interface DocsConfig {
 export interface DocsConfigInput {
 	docs: DocsConfig;
 	importMetaUrl: string;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	starlight: (config: any) => any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	docsTheme: () => any;
 	sidebarLabel?: string;
 }
 
 export function defineConfig({
 	docs,
 	importMetaUrl,
+	starlight,
+	docsTheme,
 	sidebarLabel,
 }: DocsConfigInput) {
 	const docsDir = fileURLToPath(new URL(".", importMetaUrl));

--- a/packages/astro-config/index.ts
+++ b/packages/astro-config/index.ts
@@ -1,6 +1,8 @@
 import { relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import type starlight from "@astrojs/starlight";
+import type { docsTheme } from "@theholocron/docs-theme";
 import { defineConfig as astroDefineConfig } from "astro/config";
 
 interface SidebarGroup {
@@ -19,10 +21,8 @@ export interface DocsConfig {
 export interface DocsConfigInput {
 	docs: DocsConfig;
 	importMetaUrl: string;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	starlight: (config: any) => any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	docsTheme: () => any;
+	starlight: typeof starlight;
+	docsTheme: typeof docsTheme;
 	sidebarLabel?: string;
 }
 

--- a/packages/astro-config/package.json
+++ b/packages/astro-config/package.json
@@ -46,8 +46,6 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@astrojs/starlight": ">=0.30.0",
-    "@theholocron/docs-theme": ">=1.2.2",
     "astro": ">=5.0.0"
   },
   "engines": {

--- a/packages/astro-config/tsdown.config.ts
+++ b/packages/astro-config/tsdown.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
 	fixedExtension: false,
 	dts: true,
 	clean: true,
+	external: ["@astrojs/starlight", "@theholocron/docs-theme"],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,18 +110,18 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.41.5
         version: 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
+      '@theholocron/astro-config':
+        specifier: ^7.8.0
+        version: 7.8.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
       '@theholocron/configs-docs':
         specifier: workspace:*
         version: link:../packages/configs-docs
       '@theholocron/docs-theme':
-        specifier: ^1.1.0
-        version: 1.1.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^1.3.0
+        version: 1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
       astro:
         specifier: ^7.1.5
         version: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)
-      gray-matter:
-        specifier: ^4.0.3
-        version: 4.0.3
     devDependencies:
       '@types/node':
         specifier: ^26.1.2
@@ -2921,19 +2921,27 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@theholocron/astro-config@7.8.0':
+    resolution: {integrity: sha512-5fKu7x31YhPCODxbw2fOT6/wdCjiUmbOr1HXxzQlneW4dmhycgz3vOZbgPqQrDN4q/0gunmVkbHKO8hhthhyzg==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@astrojs/starlight': '>=0.30.0'
+      '@theholocron/docs-theme': '>=1.2.2'
+      astro: '>=5.0.0'
+
   '@theholocron/cli@3.4.0':
     resolution: {integrity: sha512-/lusysF8FN/qtLnurldqy6SSnQDw9gdjcvi8qGeKlOS4z2VK/qY1l32DE6pEp0krRz4iknPf6bxRh4W2pxjU7Q==}
     hasBin: true
 
-  '@theholocron/docs-theme@1.1.0':
-    resolution: {integrity: sha512-UI9NvBg5L5v3HRQ6kVmT4Pjy8SQ2Du+8b1AslERF/fTtngxapl68NEPCcBc+YwVsg8xB87I6t3UMTdDaqAiAzQ==}
+  '@theholocron/docs-theme@1.2.2':
+    resolution: {integrity: sha512-fEGxPR61wZgz1aC8GZI9t38W3+s3z0dmLrDOwmqkHRhXxSASmhytXhNqWv5yCQ0KDy9vk8uPRHoTvZKxjOAy9Q==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@astrojs/starlight': '>=0.30.0'
       astro: '>=5.0.0'
 
-  '@theholocron/docs-theme@1.2.2':
-    resolution: {integrity: sha512-fEGxPR61wZgz1aC8GZI9t38W3+s3z0dmLrDOwmqkHRhXxSASmhytXhNqWv5yCQ0KDy9vk8uPRHoTvZKxjOAy9Q==}
+  '@theholocron/docs-theme@1.3.0':
+    resolution: {integrity: sha512-F6+j8kPySJ01cxmRlRxY/zaPaP106LsmehMQnDUHWTYfVaIWm9GfVp6xa2Jaix2tESujIXUSMhTyLRo1Z9bqGA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@astrojs/starlight': '>=0.30.0'
@@ -10744,6 +10752,12 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@theholocron/astro-config@7.8.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@astrojs/starlight': 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
+      '@theholocron/docs-theme': 1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
+      astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)
+
   '@theholocron/cli@3.4.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(vitest@4.1.10)':
     dependencies:
       '@napi-rs/keyring': 1.3.0
@@ -10760,13 +10774,13 @@ snapshots:
       - supports-color
       - vitest
 
-  '@theholocron/docs-theme@1.1.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
+  '@theholocron/docs-theme@1.2.2(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@astrojs/starlight': 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
       astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)
       gray-matter: 4.0.3
 
-  '@theholocron/docs-theme@1.2.2(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
+  '@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@astrojs/starlight': 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
       astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,8 +111,8 @@ importers:
         specifier: ^0.41.5
         version: 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
       '@theholocron/astro-config':
-        specifier: ^7.8.0
-        version: 7.8.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: workspace:*
+        version: link:../packages/astro-config
       '@theholocron/configs-docs':
         specifier: workspace:*
         version: link:../packages/configs-docs
@@ -2920,14 +2920,6 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
-
-  '@theholocron/astro-config@7.8.0':
-    resolution: {integrity: sha512-5fKu7x31YhPCODxbw2fOT6/wdCjiUmbOr1HXxzQlneW4dmhycgz3vOZbgPqQrDN4q/0gunmVkbHKO8hhthhyzg==}
-    engines: {node: '>=22.0.0'}
-    peerDependencies:
-      '@astrojs/starlight': '>=0.30.0'
-      '@theholocron/docs-theme': '>=1.2.2'
-      astro: '>=5.0.0'
 
   '@theholocron/cli@3.4.0':
     resolution: {integrity: sha512-/lusysF8FN/qtLnurldqy6SSnQDw9gdjcvi8qGeKlOS4z2VK/qY1l32DE6pEp0krRz4iknPf6bxRh4W2pxjU7Q==}
@@ -10751,12 +10743,6 @@ snapshots:
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
-
-  '@theholocron/astro-config@7.8.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))':
-    dependencies:
-      '@astrojs/starlight': 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3)
-      '@theholocron/docs-theme': 1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0))
-      astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)
 
   '@theholocron/cli@3.4.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(vitest@4.1.10)':
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "tasks": {
-    "build": { "outputs": ["dist/**"] },
+    "build": { "dependsOn": ["^build"], "outputs": ["dist/**"] },
     "lint": { "dependsOn": ["^build"] },
     "test": { "dependsOn": ["build", "^build"] },
     "typecheck": { "dependsOn": ["^build"] }


### PR DESCRIPTION
## Summary

`@theholocron/astro-config@7.8.0` fails in monorepo contexts (e.g. the themes repo) because:
1. `@astrojs/starlight` ships TypeScript source — Node.js's built-in type stripper can't process it when loaded transitively from a compiled node_module
2. Rolldown follows `import type` into Starlight's source and hits unresolvable `?raw` asset imports during build

**Fixes:**
- Accept `starlight` and `docsTheme` as inputs (dependency injection) — keeps framework imports in the consumer's `astro.config.ts` where Astro's loader handles them
- Use `import type` for type-only references, with `external` in tsdown config to prevent Rolldown from following them

## Usage after this fix

\`\`\`ts
import starlight from "@astrojs/starlight";
import { docsTheme } from "@theholocron/docs-theme";
import { defineConfig } from "@theholocron/astro-config";
import clientsConfig from "@theholocron/clients-docs";

export default defineConfig({ docs: clientsConfig, importMetaUrl: import.meta.url, starlight, docsTheme });
\`\`\`

## Test plan

- [x] Build passes
- [x] All 4 tests pass
- [x] Typecheck clean