### PR TITLE
chore: add docs/dist/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ dist
 super-linter-output
 test-report.junit.xml
 docs/.astro/
+docs/dist/
 
 # managed by holocron setup — skills
 /.agents/skills/


### PR DESCRIPTION
## Summary

Adds `docs/dist/` alongside `docs/.astro/` in `.gitignore` for consistency with the rest of the org (skills was the only repo that had both; all others only had `.astro/`).

Refs theholocron/holocron#288