### PR TITLE
docs: 📝 replace npm install with pnpm add in READMEs and docs content

### DIFF
--- a/packages/astro-config/README.md
+++ b/packages/astro-config/README.md
@@ -5,7 +5,7 @@ An [Astro configuration](https://docs.astro.build/en/reference/configuration-ref
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/astro-config
+pnpm add -D @theholocron/astro-config
 ```
 
 ## Usage

--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -5,7 +5,7 @@ A [browserslist configuration](https://github.com/browserslist/browserslist#shar
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/browserslist-config
+pnpm add -D @theholocron/browserslist-config
 ```
 
 ## Usage

--- a/packages/configs-docs/content/astro-config.md
+++ b/packages/configs-docs/content/astro-config.md
@@ -8,7 +8,7 @@ description: Astro configuration factory for theholocron docs sites.
 ## Install
 
 ```bash
-npm i -D @theholocron/astro-config
+pnpm add -D @theholocron/astro-config
 ```
 
 ## Usage

--- a/packages/configs-docs/content/browserslist-config.md
+++ b/packages/configs-docs/content/browserslist-config.md
@@ -8,7 +8,7 @@ description: Shared Browserslist target browser list for theholocron projects.
 ## Install
 
 ```bash
-npm i -D @theholocron/browserslist-config
+pnpm add -D @theholocron/browserslist-config
 ```
 
 ## Usage

--- a/packages/configs-docs/content/commitlint-config.md
+++ b/packages/configs-docs/content/commitlint-config.md
@@ -8,7 +8,7 @@ description: CommitLint rules for Conventional Commits used across theholocron p
 ## Install
 
 ```bash
-npm i -D @theholocron/commitlint-config
+pnpm add -D @theholocron/commitlint-config
 ```
 
 ## Usage

--- a/packages/configs-docs/content/eslint-config.md
+++ b/packages/configs-docs/content/eslint-config.md
@@ -8,7 +8,7 @@ description: Composable ESLint configurations and bundles for theholocron projec
 ## Install
 
 ```bash
-npm i -D @theholocron/eslint-config eslint
+pnpm add -D @theholocron/eslint-config eslint
 ```
 
 ## Configs

--- a/packages/configs-docs/content/holocron-config.md
+++ b/packages/configs-docs/content/holocron-config.md
@@ -8,7 +8,7 @@ description: Shareable Holocron CLI configuration presets for theholocron reposi
 ## Install
 
 ```bash
-npm i -D @theholocron/holocron-config
+pnpm add -D @theholocron/holocron-config
 ```
 
 ## Usage

--- a/packages/configs-docs/content/index.md
+++ b/packages/configs-docs/content/index.md
@@ -30,7 +30,7 @@ sidebar:
 Each package is published independently to npm:
 
 ```bash
-npm i -D @theholocron/eslint-config
+pnpm add -D @theholocron/eslint-config
 ```
 
 All packages follow the same lockstep versioning — see the

--- a/packages/configs-docs/content/lint-staged-config.md
+++ b/packages/configs-docs/content/lint-staged-config.md
@@ -8,7 +8,7 @@ description: Lint-staged hooks configuration for theholocron projects.
 ## Install
 
 ```bash
-npm i -D @theholocron/lint-staged-config lint-staged
+pnpm add -D @theholocron/lint-staged-config lint-staged
 ```
 
 ## Usage

--- a/packages/configs-docs/content/prettier-config.md
+++ b/packages/configs-docs/content/prettier-config.md
@@ -8,7 +8,7 @@ description: Shared Prettier formatting rules for theholocron projects.
 ## Install
 
 ```bash
-npm i -D @theholocron/prettier-config prettier
+pnpm add -D @theholocron/prettier-config prettier
 ```
 
 ## Usage

--- a/packages/configs-docs/content/semantic-release-config.md
+++ b/packages/configs-docs/content/semantic-release-config.md
@@ -8,7 +8,7 @@ description: semantic-release configuration factory with Conventional Commits su
 ## Install
 
 ```bash
-npm i -D @theholocron/semantic-release-config semantic-release
+pnpm add -D @theholocron/semantic-release-config semantic-release
 ```
 
 ## Usage

--- a/packages/configs-docs/content/storybook-config.md
+++ b/packages/configs-docs/content/storybook-config.md
@@ -8,7 +8,7 @@ description: Shared Storybook main and preview configuration for theholocron com
 ## Install
 
 ```bash
-npm i -D @theholocron/storybook-config
+pnpm add -D @theholocron/storybook-config
 ```
 
 ## Usage

--- a/packages/configs-docs/content/stylelint-config.md
+++ b/packages/configs-docs/content/stylelint-config.md
@@ -8,7 +8,7 @@ description: Shared Stylelint CSS rules for theholocron projects.
 ## Install
 
 ```bash
-npm i -D @theholocron/stylelint-config stylelint
+pnpm add -D @theholocron/stylelint-config stylelint
 ```
 
 ## Usage

--- a/packages/configs-docs/content/tsconfig.md
+++ b/packages/configs-docs/content/tsconfig.md
@@ -8,7 +8,7 @@ description: TypeScript base configurations for theholocron projects.
 ## Install
 
 ```bash
-npm i -D @theholocron/tsconfig
+pnpm add -D @theholocron/tsconfig
 ```
 
 ## Presets

--- a/packages/configs-docs/content/tsdown-config.md
+++ b/packages/configs-docs/content/tsdown-config.md
@@ -8,7 +8,7 @@ description: Shared tsdown build presets for theholocron packages.
 ## Install
 
 ```bash
-npm i -D @theholocron/tsdown-config tsdown
+pnpm add -D @theholocron/tsdown-config tsdown
 ```
 
 ## Presets

--- a/packages/configs-docs/content/vite-config.md
+++ b/packages/configs-docs/content/vite-config.md
@@ -8,7 +8,7 @@ description: Vite configuration presets for libraries, React apps, and Node tool
 ## Install
 
 ```bash
-npm i -D @theholocron/vite-config vite
+pnpm add -D @theholocron/vite-config vite
 ```
 
 ## Presets

--- a/packages/configs-docs/content/vitest-config.md
+++ b/packages/configs-docs/content/vitest-config.md
@@ -8,7 +8,7 @@ description: Vitest configuration presets for libraries, React apps, and Storybo
 ## Install
 
 ```bash
-npm i -D @theholocron/vitest-config vitest
+pnpm add -D @theholocron/vitest-config vitest
 ```
 
 ## Presets

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -5,35 +5,35 @@ A [ESLint configuration](https://eslint.org/docs/latest/use/configure/configurat
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/eslint-config
+pnpm add -D @theholocron/eslint-config
 ```
 
 Install only the peer dependencies for the presets you use (all are optional except the core):
 
 ```bash
 # Core (always required)
-npm install --save-dev @eslint/js eslint globals
+pnpm add -D @eslint/js eslint globals
 
 # TypeScript
-npm install --save-dev typescript-eslint
+pnpm add -D typescript-eslint
 
 # React
-npm install --save-dev eslint-plugin-react
+pnpm add -D eslint-plugin-react
 
 # Next.js
-npm install --save-dev @next/eslint-plugin-next
+pnpm add -D @next/eslint-plugin-next
 
 # Node.js
-npm install --save-dev eslint-plugin-n
+pnpm add -D eslint-plugin-n
 
 # Vitest
-npm install --save-dev @vitest/eslint-plugin
+pnpm add -D @vitest/eslint-plugin
 
 # Storybook
-npm install --save-dev eslint-plugin-storybook
+pnpm add -D eslint-plugin-storybook
 
 # Cypress
-npm install --save-dev eslint-plugin-cypress
+pnpm add -D eslint-plugin-cypress
 ```
 
 ## Usage

--- a/packages/lint-staged-config/README.md
+++ b/packages/lint-staged-config/README.md
@@ -5,7 +5,7 @@ A [lint-staged configuration](https://github.com/lint-staged/lint-staged#configu
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/lint-staged-config lint-staged husky
+pnpm add -D @theholocron/lint-staged-config lint-staged husky
 ```
 
 ## Usage

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -5,7 +5,7 @@ A [Prettier configuration](https://prettier.io/docs/en/configuration) for consis
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/prettier-config prettier
+pnpm add -D @theholocron/prettier-config prettier
 ```
 
 ## Usage

--- a/packages/storybook-config/README.md
+++ b/packages/storybook-config/README.md
@@ -5,13 +5,13 @@ A [Storybook configuration](https://storybook.js.org/docs/configure) with addons
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/storybook-config
+pnpm add -D @theholocron/storybook-config
 ```
 
 Install the peer dependencies for the addons you use (all are optional):
 
 ```bash
-npm install --save-dev storybook @storybook/react @storybook/react-vite \
+pnpm add -D storybook @storybook/react @storybook/react-vite \
   @storybook/addon-docs @storybook/addon-a11y @storybook/addon-links \
   @storybook/addon-themes @storybook/addon-coverage @storybook/addon-vitest \
   @storybook/test-runner @chromatic-com/storybook storybook-addon-pseudo-states \

--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -5,7 +5,7 @@ A [StyleLint configuration](https://stylelint.io/user-guide/configure/) for writ
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/stylelint-config stylelint stylelint-config-standard stylelint-config-standard-scss
+pnpm add -D @theholocron/stylelint-config stylelint stylelint-config-standard stylelint-config-standard-scss
 ```
 
 ## Usage

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -5,7 +5,7 @@ A [TypeScript configuration](https://www.typescriptlang.org/docs/handbook/tsconf
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/tsconfig
+pnpm add -D @theholocron/tsconfig
 ```
 
 ## Usage

--- a/packages/tsdown-config/README.md
+++ b/packages/tsdown-config/README.md
@@ -5,7 +5,7 @@ Shared [tsdown](https://tsdown.dev) configurations for `@theholocron` packages.
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/tsdown-config tsdown
+pnpm add -D @theholocron/tsdown-config tsdown
 ```
 
 ## Usage

--- a/packages/vite-config/README.md
+++ b/packages/vite-config/README.md
@@ -5,7 +5,7 @@ A [Vite configuration](https://vite.dev/config/) with presets for libraries, Rea
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/vite-config
+pnpm add -D @theholocron/vite-config
 ```
 
 ## Usage
@@ -64,7 +64,7 @@ All three presets automatically include [`@codecov/vite-plugin`](https://www.npm
 Install the peer dependency:
 
 ```bash
-npm install --save-dev @codecov/vite-plugin
+pnpm add -D @codecov/vite-plugin
 ```
 
 Set `CODECOV_TOKEN` as a CI secret, then add the following to your `codecov.yml` to control when Codecov posts bundle size comments on PRs:

--- a/packages/vitest-config/README.md
+++ b/packages/vitest-config/README.md
@@ -5,7 +5,7 @@ A [Vitest configuration](https://vitest.dev/config/) with presets for Node.js li
 ## Installation
 
 ```bash
-npm install --save-dev @theholocron/vitest-config
+pnpm add -D @theholocron/vitest-config
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

Replaces \`npm install --save-dev\` / \`npm i -D\` / \`npm i\` with \`pnpm add\` in all package READMEs and docs content files.