### PR TITLE
ci: 👷 add test-report.junit.xml to turbo test task outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "build": { "dependsOn": ["^build"], "outputs": ["dist/**"] },
     "lint": { "dependsOn": ["^build"] },
-    "test": { "dependsOn": ["build", "^build"] },
+    "test": { "dependsOn": ["build", "^build"], "outputs": ["test-report.junit.xml"] },
     "typecheck": { "dependsOn": ["^build"] }
   }
 }


### PR DESCRIPTION
## Summary

Adds \`test-report.junit.xml\` to the \`test\` task's \`outputs\` in \`turbo.json\`.

**Root cause of the Codecov "JUnit XML file not found" warning:** when turbo hits its cache on a docs-only PR (no \`src/**\` changes), it skips running tests and restores only what was declared in \`outputs\`. With \`"outputs": []\`, the junit file is never written to disk — so Codecov's \`test-results-action\` can't find it.

With this fix, turbo caches the junit file after the first real test run and restores it on subsequent cache hits.

Refs theholocron/holocron#288