### PR TITLE
fix: 🐛 add test:coverage task with coverage/** outputs to turbo pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lint": "turbo run lint",
     "prepare": "turbo run build",
     "test": "turbo run test",
+    "test:coverage": "turbo run test:coverage",
     "typecheck": "turbo run typecheck"
   },
   "devDependencies": {

--- a/packages/astro-config/package.json
+++ b/packages/astro-config/package.json
@@ -33,7 +33,8 @@
   "scripts": {
     "build": "tsdown",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@astrojs/starlight": "^0.41.5",

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "build": "tsdown",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@commitlint/types": "^21.2.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",

--- a/packages/holocron-config/package.json
+++ b/packages/holocron-config/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/cli": "catalog:holocron",

--- a/packages/lint-staged-config/package.json
+++ b/packages/lint-staged-config/package.json
@@ -24,7 +24,8 @@
     "build": "tsdown",
     "prepare": "husky",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/packages/semantic-release-config/package.json
+++ b/packages/semantic-release-config/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/packages/tsdown-config/package.json
+++ b/packages/tsdown-config/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/packages/vite-config/package.json
+++ b/packages/vite-config/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/packages/vitest-config/package.json
+++ b/packages/vitest-config/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,7 @@
     "build": { "dependsOn": ["^build"], "outputs": ["dist/**"] },
     "lint": { "dependsOn": ["^build"] },
     "test": { "dependsOn": ["build", "^build"], "outputs": ["test-report.junit.xml"] },
+    "test:coverage": { "dependsOn": ["build", "^build"], "outputs": ["coverage/**", "test-report.junit.xml"] },
     "typecheck": { "dependsOn": ["^build"] }
   }
 }


### PR DESCRIPTION
## Summary

`configs` was the only repo missing a `test:coverage` task in `turbo.json`. All other Turbo repos (`holocron`, `clients`, `utils`, `themes`) already have it.

The reusable `test.yml` workflow is being updated to run `pnpm test:coverage` instead of `pnpm test -- --coverage` so Turbo uses the task that properly declares `coverage/**` as an output — ensuring coverage files are cached and restored on hits rather than silently dropped.