### PR TITLE
chore: 🔧 add missing prettier.config.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@theholocron/cli": "catalog:holocron",
     "@theholocron/skills": "^1.2.0",
     "@theholocron/commitlint-config": "workspace:*",
+    "@theholocron/prettier-config": "workspace:*",
     "@theholocron/eslint-config": "workspace:*",
     "@theholocron/holocron-config": "workspace:*",
     "@theholocron/holocron-plugin-github": "catalog:holocron",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lint": "turbo run lint",
     "prepare": "turbo run build",
     "test": "turbo run test",
+    "test:coverage": "turbo run test:coverage",
     "typecheck": "turbo run typecheck"
   },
   "devDependencies": {

--- a/packages/astro-config/package.json
+++ b/packages/astro-config/package.json
@@ -33,7 +33,8 @@
   "scripts": {
     "build": "tsdown",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@astrojs/starlight": "^0.41.5",

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "build": "tsdown",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@commitlint/types": "^21.2.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",

--- a/packages/holocron-config/README.md
+++ b/packages/holocron-config/README.md
@@ -36,7 +36,7 @@ export default defineConfig({
 | Fragment    | Contents                                                                                                |
 | ----------- | ------------------------------------------------------------------------------------------------------- |
 | `repo`      | `protection: "strict"`, `properties: { lifecycle: "active", … }`                                        |
-| `workflows` | `lint`, `test`, `typecheck`, `codeql`, `review`, `stale`, `greetings`, `dependencies`, `bookkeeping-pr` |
+| `workflows` | `lint`, `test`, `typecheck`, `codeql`, `review`, `stale`, `greetings`, `dependencies`, `bookkeeping` |
 | `providers` | `source: "github"`, `ci: "github"`, `issues: ["github", { labels: … }]`                                 |
 
 Everything else — `name`, `repo.name`, `repo.topics`, and any per-repo workflow overrides (e.g. `release`) — stays in the consuming repo's config.

--- a/packages/holocron-config/package.json
+++ b/packages/holocron-config/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/cli": "catalog:holocron",

--- a/packages/lint-staged-config/package.json
+++ b/packages/lint-staged-config/package.json
@@ -24,7 +24,8 @@
     "build": "tsdown",
     "prepare": "husky",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/packages/semantic-release-config/package.json
+++ b/packages/semantic-release-config/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/packages/tsdown-config/package.json
+++ b/packages/tsdown-config/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/packages/vite-config/package.json
+++ b/packages/vite-config/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/packages/vitest-config/package.json
+++ b/packages/vitest-config/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@theholocron/tsconfig": "workspace:*",

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -1,0 +1,8 @@
+import theholocron from "@theholocron/prettier-config";
+import type { Config } from "prettier";
+
+const config = {
+	...theholocron,
+} satisfies Config;
+
+export default config;

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,7 @@
     "build": { "dependsOn": ["^build"], "outputs": ["dist/**"] },
     "lint": { "dependsOn": ["^build"] },
     "test": { "dependsOn": ["build", "^build"], "outputs": ["test-report.junit.xml"] },
+    "test:coverage": { "dependsOn": ["build", "^build"], "outputs": ["coverage/**", "test-report.junit.xml"] },
     "typecheck": { "dependsOn": ["^build"] }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `prettier.config.ts` using `@theholocron/prettier-config` with `satisfies Config`
- Adds `"@theholocron/prettier-config": "workspace:*"` to root devDependencies — the package is published from this repo but was never referenced at the root