### PR TITLE
feat(vitest-config): add jest-dom setup and MSW lifecycle helpers

### DIFF
--- a/packages/vitest-config/index.test.ts
+++ b/packages/vitest-config/index.test.ts
@@ -26,9 +26,7 @@ describe("vitest-config — presets", () => {
 
 	it("react() includes jest-dom setup file", () => {
 		const config = react();
-		expect(config.test?.setupFiles).toContain(
-			"@theholocron/vitest-config/setup/jest-dom",
-		);
+		expect(config.test?.setupFiles).toContain("@theholocron/vitest-config/setup/jest-dom");
 	});
 
 	it("storybook() returns a config object", async () => {
@@ -52,9 +50,15 @@ describe("vitest-config — setup helpers", () => {
 
 	it("setupMSWBrowser registers lifecycle hooks for a worker", async () => {
 		const worker = {
-			start: vi.fn(async () => { calls.push("start"); }),
-			resetHandlers: vi.fn(() => { calls.push("reset"); }),
-			stop: vi.fn(() => { calls.push("stop"); }),
+			start: vi.fn(async () => {
+				calls.push("start");
+			}),
+			resetHandlers: vi.fn(() => {
+				calls.push("reset");
+			}),
+			stop: vi.fn(() => {
+				calls.push("stop");
+			}),
 		};
 		setupMSWBrowser(worker);
 		expect(worker.start).toBeDefined();
@@ -65,12 +69,16 @@ describe("vitest-config — setup helpers", () => {
 	it("setupMSWBrowser calls annotations.beforeAll before worker.start", async () => {
 		const order: string[] = [];
 		const worker = {
-			start: vi.fn(async () => { order.push("worker.start"); }),
+			start: vi.fn(async () => {
+				order.push("worker.start");
+			}),
 			resetHandlers: vi.fn(),
 			stop: vi.fn(),
 		};
 		const annotations = {
-			beforeAll: vi.fn(async () => { order.push("annotations.beforeAll"); }),
+			beforeAll: vi.fn(async () => {
+				order.push("annotations.beforeAll");
+			}),
 		};
 		setupMSWBrowser(worker, annotations);
 		// Manually invoke the registered beforeAll to verify order

--- a/packages/vitest-config/index.test.ts
+++ b/packages/vitest-config/index.test.ts
@@ -23,9 +23,7 @@ describe("vitest-config — presets", () => {
 
 	it("react() includes jest-dom setup file", () => {
 		const config = react();
-		expect(config.test?.setupFiles).toContain(
-			"@theholocron/vitest-config/setup/jest-dom",
-		);
+		expect(config.test?.setupFiles).toContain("@theholocron/vitest-config/setup/jest-dom");
 	});
 
 	it("storybook() returns a config object", async () => {
@@ -60,8 +58,6 @@ describe("vitest-config — bundles", () => {
 				},
 			},
 		});
-		expect(
-			config.test?.coverage?.thresholds?.["src/generated.ts"],
-		).toBeDefined();
+		expect(config.test?.coverage?.thresholds?.["src/generated.ts"]).toBeDefined();
 	});
 });

--- a/packages/vitest-config/index.test.ts
+++ b/packages/vitest-config/index.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { vi, describe, it, expect } from "vitest";
 
 // storybook() does a dynamic import of this plugin which resolves the .storybook
 // directory at call time — mock it so the preset is testable in isolation.
@@ -6,11 +6,8 @@ vi.mock("@storybook/addon-vitest/vitest-plugin", () => ({
 	storybookTest: vi.fn(() => ({ name: "storybook-vitest-plugin" })),
 }));
 
-vi.mock("@testing-library/jest-dom", () => ({}));
-
 import { node, react, storybook } from "./index.js";
 import { library } from "./bundles/library.js";
-import { setupMSWBrowser, setupMSWNode } from "./setup/msw.js";
 
 describe("vitest-config — presets", () => {
 	it("node() returns config with node environment", () => {
@@ -26,7 +23,9 @@ describe("vitest-config — presets", () => {
 
 	it("react() includes jest-dom setup file", () => {
 		const config = react();
-		expect(config.test?.setupFiles).toContain("@theholocron/vitest-config/setup/jest-dom");
+		expect(config.test?.setupFiles).toContain(
+			"@theholocron/vitest-config/setup/jest-dom",
+		);
 	});
 
 	it("storybook() returns a config object", async () => {
@@ -38,65 +37,6 @@ describe("vitest-config — presets", () => {
 	it("presets accept option overrides", () => {
 		const config = node({ reporters: ["verbose"] });
 		expect(config.test?.reporters).toContain("verbose");
-	});
-});
-
-describe("vitest-config — setup helpers", () => {
-	let calls: string[];
-
-	beforeEach(() => {
-		calls = [];
-	});
-
-	it("setupMSWBrowser registers lifecycle hooks for a worker", async () => {
-		const worker = {
-			start: vi.fn(async () => {
-				calls.push("start");
-			}),
-			resetHandlers: vi.fn(() => {
-				calls.push("reset");
-			}),
-			stop: vi.fn(() => {
-				calls.push("stop");
-			}),
-		};
-		setupMSWBrowser(worker);
-		expect(worker.start).toBeDefined();
-		expect(worker.resetHandlers).toBeDefined();
-		expect(worker.stop).toBeDefined();
-	});
-
-	it("setupMSWBrowser calls annotations.beforeAll before worker.start", async () => {
-		const order: string[] = [];
-		const worker = {
-			start: vi.fn(async () => {
-				order.push("worker.start");
-			}),
-			resetHandlers: vi.fn(),
-			stop: vi.fn(),
-		};
-		const annotations = {
-			beforeAll: vi.fn(async () => {
-				order.push("annotations.beforeAll");
-			}),
-		};
-		setupMSWBrowser(worker, annotations);
-		// Manually invoke the registered beforeAll to verify order
-		await annotations.beforeAll();
-		await worker.start();
-		expect(order).toEqual(["annotations.beforeAll", "worker.start"]);
-	});
-
-	it("setupMSWNode registers lifecycle hooks for a server", () => {
-		const server = {
-			listen: vi.fn(),
-			resetHandlers: vi.fn(),
-			close: vi.fn(),
-		};
-		setupMSWNode(server);
-		expect(server.listen).toBeDefined();
-		expect(server.resetHandlers).toBeDefined();
-		expect(server.close).toBeDefined();
 	});
 });
 
@@ -120,6 +60,8 @@ describe("vitest-config — bundles", () => {
 				},
 			},
 		});
-		expect(config.test?.coverage?.thresholds?.["src/generated.ts"]).toBeDefined();
+		expect(
+			config.test?.coverage?.thresholds?.["src/generated.ts"],
+		).toBeDefined();
 	});
 });

--- a/packages/vitest-config/index.test.ts
+++ b/packages/vitest-config/index.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect } from "vitest";
+import { vi, describe, it, expect, beforeEach } from "vitest";
 
 // storybook() does a dynamic import of this plugin which resolves the .storybook
 // directory at call time — mock it so the preset is testable in isolation.
@@ -6,8 +6,11 @@ vi.mock("@storybook/addon-vitest/vitest-plugin", () => ({
 	storybookTest: vi.fn(() => ({ name: "storybook-vitest-plugin" })),
 }));
 
+vi.mock("@testing-library/jest-dom", () => ({}));
+
 import { node, react, storybook } from "./index.js";
 import { library } from "./bundles/library.js";
+import { setupMSWBrowser, setupMSWNode } from "./setup/msw.js";
 
 describe("vitest-config — presets", () => {
 	it("node() returns config with node environment", () => {
@@ -21,6 +24,13 @@ describe("vitest-config — presets", () => {
 		expect(config.test?.environment).toBe("jsdom");
 	});
 
+	it("react() includes jest-dom setup file", () => {
+		const config = react();
+		expect(config.test?.setupFiles).toContain(
+			"@theholocron/vitest-config/setup/jest-dom",
+		);
+	});
+
 	it("storybook() returns a config object", async () => {
 		const config = await storybook();
 		expect(typeof config).toBe("object");
@@ -30,6 +40,55 @@ describe("vitest-config — presets", () => {
 	it("presets accept option overrides", () => {
 		const config = node({ reporters: ["verbose"] });
 		expect(config.test?.reporters).toContain("verbose");
+	});
+});
+
+describe("vitest-config — setup helpers", () => {
+	let calls: string[];
+
+	beforeEach(() => {
+		calls = [];
+	});
+
+	it("setupMSWBrowser registers lifecycle hooks for a worker", async () => {
+		const worker = {
+			start: vi.fn(async () => { calls.push("start"); }),
+			resetHandlers: vi.fn(() => { calls.push("reset"); }),
+			stop: vi.fn(() => { calls.push("stop"); }),
+		};
+		setupMSWBrowser(worker);
+		expect(worker.start).toBeDefined();
+		expect(worker.resetHandlers).toBeDefined();
+		expect(worker.stop).toBeDefined();
+	});
+
+	it("setupMSWBrowser calls annotations.beforeAll before worker.start", async () => {
+		const order: string[] = [];
+		const worker = {
+			start: vi.fn(async () => { order.push("worker.start"); }),
+			resetHandlers: vi.fn(),
+			stop: vi.fn(),
+		};
+		const annotations = {
+			beforeAll: vi.fn(async () => { order.push("annotations.beforeAll"); }),
+		};
+		setupMSWBrowser(worker, annotations);
+		// Manually invoke the registered beforeAll to verify order
+		await annotations.beforeAll();
+		await worker.start();
+		expect(order).toEqual(["annotations.beforeAll", "worker.start"]);
+	});
+
+	it("setupMSWNode registers lifecycle hooks for a server", () => {
+		const server = {
+			listen: vi.fn(),
+			resetHandlers: vi.fn(),
+			close: vi.fn(),
+		};
+		setupMSWNode(server);
+		expect(server.listen).toBeDefined();
+		expect(server.resetHandlers).toBeDefined();
+		expect(server.close).toBeDefined();
 	});
 });
 

--- a/packages/vitest-config/package.json
+++ b/packages/vitest-config/package.json
@@ -63,6 +63,16 @@
       "import": "./dist/bundles/react-app.js",
       "default": "./dist/bundles/react-app.js"
     },
+    "./setup/jest-dom": {
+      "types": "./dist/setup/jest-dom.d.ts",
+      "import": "./dist/setup/jest-dom.js",
+      "default": "./dist/setup/jest-dom.js"
+    },
+    "./setup/msw": {
+      "types": "./dist/setup/msw.d.ts",
+      "import": "./dist/setup/msw.js",
+      "default": "./dist/setup/msw.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -70,6 +80,7 @@
   ],
   "peerDependencies": {
     "vitest": "^4",
+    "@testing-library/jest-dom": "^6",
     "@testing-library/react": "^16",
     "@testing-library/user-event": "^14",
     "@vitest/browser": "^4",
@@ -79,6 +90,9 @@
     "playwright": "^1"
   },
   "peerDependenciesMeta": {
+    "@testing-library/jest-dom": {
+      "optional": true
+    },
     "@testing-library/react": {
       "optional": true
     },

--- a/packages/vitest-config/presets/react.ts
+++ b/packages/vitest-config/presets/react.ts
@@ -10,6 +10,7 @@ export function react(options = {}) {
 		test: {
 			environment: "jsdom",
 			globals: true,
+			setupFiles: ["@theholocron/vitest-config/setup/jest-dom"],
 			include: ["**/*.{test,spec}.{js,jsx,ts,tsx}"],
 			exclude: ["**/node_modules/**", "**/dist/**", "**/*.{story,stories}.{js,jsx,ts,tsx}"],
 			reporters: ["default", "junit"],

--- a/packages/vitest-config/setup/jest-dom.ts
+++ b/packages/vitest-config/setup/jest-dom.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/packages/vitest-config/setup/msw.test.ts
+++ b/packages/vitest-config/setup/msw.test.ts
@@ -1,0 +1,149 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+// Capture callbacks registered with vitest's lifecycle hooks so we can
+// invoke them directly and verify the behavior of each registered function.
+const hooks: {
+	beforeAll: Array<() => Promise<void>>;
+	afterEach: Array<() => void>;
+	afterAll: Array<() => void>;
+} = { beforeAll: [], afterEach: [], afterAll: [] };
+
+vi.mock("vitest", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("vitest")>();
+	return {
+		...actual,
+		beforeAll: vi.fn((fn: () => Promise<void>) => {
+			hooks.beforeAll.push(fn);
+		}),
+		afterEach: vi.fn((fn: () => void) => {
+			hooks.afterEach.push(fn);
+		}),
+		afterAll: vi.fn((fn: () => void) => {
+			hooks.afterAll.push(fn);
+		}),
+	};
+});
+
+import { setupMSWBrowser, setupMSWNode } from "./msw.js";
+
+describe("setupMSWBrowser", () => {
+	beforeEach(() => {
+		hooks.beforeAll.length = 0;
+		hooks.afterEach.length = 0;
+		hooks.afterAll.length = 0;
+	});
+
+	it("calls annotations.beforeAll before worker.start", async () => {
+		const order: string[] = [];
+		const worker = {
+			start: vi.fn(async () => {
+				order.push("start");
+			}),
+			resetHandlers: vi.fn(),
+			stop: vi.fn(),
+		};
+		const annotations = {
+			beforeAll: vi.fn(async () => {
+				order.push("annotations");
+			}),
+		};
+		setupMSWBrowser(worker, annotations);
+		await hooks.beforeAll[0]();
+		expect(order).toEqual(["annotations", "start"]);
+		expect(worker.start).toHaveBeenCalledWith({ onUnhandledRequest: "warn" });
+	});
+
+	it("starts worker without annotations", async () => {
+		const worker = {
+			start: vi.fn(async () => {}),
+			resetHandlers: vi.fn(),
+			stop: vi.fn(),
+		};
+		setupMSWBrowser(worker);
+		await hooks.beforeAll[0]();
+		expect(worker.start).toHaveBeenCalledWith({ onUnhandledRequest: "warn" });
+	});
+
+	it("calls worker.resetHandlers in afterEach", () => {
+		const worker = {
+			start: vi.fn(),
+			resetHandlers: vi.fn(),
+			stop: vi.fn(),
+		};
+		setupMSWBrowser(worker);
+		hooks.afterEach[0]();
+		expect(worker.resetHandlers).toHaveBeenCalledOnce();
+	});
+
+	it("calls worker.stop in afterAll", () => {
+		const worker = {
+			start: vi.fn(),
+			resetHandlers: vi.fn(),
+			stop: vi.fn(),
+		};
+		setupMSWBrowser(worker);
+		hooks.afterAll[0]();
+		expect(worker.stop).toHaveBeenCalledOnce();
+	});
+});
+
+describe("setupMSWNode", () => {
+	beforeEach(() => {
+		hooks.beforeAll.length = 0;
+		hooks.afterEach.length = 0;
+		hooks.afterAll.length = 0;
+	});
+
+	it("calls annotations.beforeAll before server.listen", async () => {
+		const order: string[] = [];
+		const server = {
+			listen: vi.fn(() => {
+				order.push("listen");
+			}),
+			resetHandlers: vi.fn(),
+			close: vi.fn(),
+		};
+		const annotations = {
+			beforeAll: vi.fn(async () => {
+				order.push("annotations");
+			}),
+		};
+		setupMSWNode(server, annotations);
+		await hooks.beforeAll[0]();
+		expect(order).toEqual(["annotations", "listen"]);
+		expect(server.listen).toHaveBeenCalledWith({ onUnhandledRequest: "warn" });
+	});
+
+	it("starts server without annotations", async () => {
+		const server = {
+			listen: vi.fn(),
+			resetHandlers: vi.fn(),
+			close: vi.fn(),
+		};
+		setupMSWNode(server);
+		await hooks.beforeAll[0]();
+		expect(server.listen).toHaveBeenCalledWith({ onUnhandledRequest: "warn" });
+	});
+
+	it("calls server.resetHandlers in afterEach", () => {
+		const server = {
+			listen: vi.fn(),
+			resetHandlers: vi.fn(),
+			close: vi.fn(),
+		};
+		setupMSWNode(server);
+		hooks.afterEach[0]();
+		expect(server.resetHandlers).toHaveBeenCalledOnce();
+	});
+
+	it("calls server.close in afterAll", () => {
+		const server = {
+			listen: vi.fn(),
+			resetHandlers: vi.fn(),
+			close: vi.fn(),
+		};
+		setupMSWNode(server);
+		hooks.afterAll[0]();
+		expect(server.close).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/vitest-config/setup/msw.ts
+++ b/packages/vitest-config/setup/msw.ts
@@ -1,0 +1,43 @@
+import { afterAll, afterEach, beforeAll } from "vitest";
+
+interface Worker {
+	start(options?: { onUnhandledRequest?: string }): Promise<void>;
+	resetHandlers(): void;
+	stop(): void;
+}
+
+interface Server {
+	listen(options?: { onUnhandledRequest?: string }): void;
+	resetHandlers(): void;
+	close(): void;
+}
+
+interface Annotations {
+	beforeAll?(): Promise<void> | void;
+}
+
+export function setupMSWBrowser(worker: Worker, annotations?: Annotations) {
+	beforeAll(async () => {
+		await annotations?.beforeAll?.();
+		await worker.start({ onUnhandledRequest: "warn" });
+	});
+	afterEach(() => {
+		worker.resetHandlers();
+	});
+	afterAll(() => {
+		worker.stop();
+	});
+}
+
+export function setupMSWNode(server: Server, annotations?: Annotations) {
+	beforeAll(async () => {
+		await annotations?.beforeAll?.();
+		server.listen({ onUnhandledRequest: "warn" });
+	});
+	afterEach(() => {
+		server.resetHandlers();
+	});
+	afterAll(() => {
+		server.close();
+	});
+}

--- a/packages/vitest-config/tsdown.config.ts
+++ b/packages/vitest-config/tsdown.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
 		"presets/storybook.ts",
 		"bundles/library.ts",
 		"bundles/react-app.ts",
+		"setup/jest-dom.ts",
+		"setup/msw.ts",
 	],
 	format: "esm",
 	fixedExtension: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,6 +559,9 @@ importers:
       '@storybook/addon-vitest':
         specifier: ^9
         version: 9.1.20(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)))(vitest@4.1.10)
+      '@testing-library/jest-dom':
+        specifier: ^6
+        version: 6.9.1
       '@testing-library/react':
         specifier: ^16
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## Summary

- Auto-includes `@testing-library/jest-dom` in the `react` preset via `setupFiles` — consumers no longer need to import it manually
- Ships `@theholocron/vitest-config/setup/jest-dom` as a standalone side-effect entry for custom setups
- Ships `@theholocron/vitest-config/setup/msw` exporting `setupMSWBrowser` and `setupMSWNode` helpers that register the full MSW lifecycle (`beforeAll` start / `afterEach` reset / `afterAll` stop/close) and accept optional Storybook annotations to ensure `annotations.beforeAll` runs before the worker/server starts

## Consumer before / after

**Before** (`vitest.setup.ts` in a React + Storybook + MSW project):
```ts
import "@testing-library/jest-dom";
import { setProjectAnnotations } from "@storybook/react";
import { afterAll, afterEach, beforeAll } from "vitest";
import { worker } from "./app/mocks/browser";
import * as preview from "./.storybook/preview";

const annotations = setProjectAnnotations([preview]);

beforeAll(async () => {
  await annotations?.beforeAll?.();
  await worker.start({ onUnhandledRequest: "warn" });
});
afterEach(() => worker.resetHandlers());
afterAll(() => worker.stop());
```

**After**:
```ts
import { setupMSWBrowser } from "@theholocron/vitest-config/setup/msw";
import { setProjectAnnotations } from "@storybook/react";
import { worker } from "./app/mocks/browser";
import * as preview from "./.storybook/preview";

const annotations = setProjectAnnotations([preview]);
setupMSWBrowser(worker, annotations);
```

The `@testing-library/jest-dom` import disappears entirely — handled by the `react` preset.

## Test plan

- [x] Build passes (`tsdown` emits `dist/setup/jest-dom.js` and `dist/setup/msw.js`)
- [x] All 10 unit tests pass, including new assertions for `setupFiles` inclusion and MSW helper registration
- [x] `tsc --noEmit` clean