### PR TITLE
fix(eslint-config): wrap react plugin with fixupConfigRules for ESLint v10 compat

### DIFF
--- a/packages/eslint-config/configs/react.ts
+++ b/packages/eslint-config/configs/react.ts
@@ -1,7 +1,11 @@
+import { fixupConfigRules } from "@eslint/compat";
 import react from "eslint-plugin-react";
 
 export function reactConfig() {
-	return [react.configs.flat.recommended, react.configs.flat["jsx-runtime"]];
+	return fixupConfigRules([
+		react.configs.flat.recommended,
+		react.configs.flat["jsx-runtime"],
+	]);
 }
 
 export { reactConfig as react };

--- a/packages/eslint-config/configs/react.ts
+++ b/packages/eslint-config/configs/react.ts
@@ -2,10 +2,7 @@ import { fixupConfigRules } from "@eslint/compat";
 import react from "eslint-plugin-react";
 
 export function reactConfig() {
-	return fixupConfigRules([
-		react.configs.flat.recommended,
-		react.configs.flat["jsx-runtime"],
-	]);
+	return fixupConfigRules([react.configs.flat.recommended, react.configs.flat["jsx-runtime"]]);
 }
 
 export { reactConfig as react };

--- a/packages/eslint-config/index.test.ts
+++ b/packages/eslint-config/index.test.ts
@@ -33,9 +33,7 @@ describe("eslint-config — individual configs", () => {
 
 	it("react() config runs without throwing on ESLint v10 context API", () => {
 		const linter = new Linter({ configType: "flat" });
-		expect(() =>
-			linter.verify("const x = 1;", react() as Parameters<Linter["verify"]>[1]),
-		).not.toThrow();
+		expect(() => linter.verify("const x = 1;", react() as Parameters<Linter["verify"]>[1])).not.toThrow();
 	});
 });
 

--- a/packages/eslint-config/index.test.ts
+++ b/packages/eslint-config/index.test.ts
@@ -1,3 +1,4 @@
+import { Linter } from "eslint";
 import { describe, it, expect } from "vitest";
 import { base } from "./configs/base.js";
 import { typescript } from "./configs/typescript.js";
@@ -28,6 +29,13 @@ describe("eslint-config — individual configs", () => {
 		const config = react();
 		expect(Array.isArray(config)).toBe(true);
 		expect(config.length).toBeGreaterThan(0);
+	});
+
+	it("react() config runs without throwing on ESLint v10 context API", () => {
+		const linter = new Linter({ configType: "flat" });
+		expect(() =>
+			linter.verify("const x = 1;", react() as Parameters<Linter["verify"]>[1]),
+		).not.toThrow();
 	});
 });
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -27,6 +27,9 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },
+  "dependencies": {
+    "@eslint/compat": "^2.1.0"
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.0",
     "@theholocron/tsconfig": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
 
   packages/eslint-config:
     dependencies:
+      '@eslint/compat':
+        specifier: ^2.1.0
+        version: 2.1.0(eslint@10.8.0(jiti@2.6.1))
       '@next/eslint-plugin-next':
         specifier: ^16
         version: 16.2.10
@@ -1490,6 +1493,15 @@ packages:
   '@eslint-community/regexpp@4.12.2':
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/compat@2.1.0':
+    resolution: {integrity: sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^8.40 || 9 || 10
+    peerDependenciesMeta:
+      eslint:
+        optional: true
 
   '@eslint/config-array@0.23.5':
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
@@ -9584,6 +9596,12 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/compat@2.1.0(eslint@10.8.0(jiti@2.6.1))':
+    dependencies:
+      '@eslint/core': 1.2.1
+    optionalDependencies:
+      eslint: 10.8.0(jiti@2.6.1)
 
   '@eslint/config-array@0.23.5':
     dependencies:


### PR DESCRIPTION
## Summary

- `eslint-plugin-react@7` calls `context.getFilename()` internally, which was removed in ESLint v10, causing a `TypeError` at lint time
- Wraps the react flat config array with `fixupConfigRules` from `@eslint/compat`, which stubs out removed context methods for plugins that haven't migrated yet
- Adds `@eslint/compat` as a runtime dependency (internal impl detail, not a peer)
- Adds a smoke-test that actually runs the ESLint linter against the react config to catch this class of API breakage going forward

## Test plan

- [x] All 7 tests pass including new `react() config runs without throwing on ESLint v10 context API` assertion
- [x] `tsc --noEmit` clean
- [x] Build clean