### PR TITLE
feat(vite-config): add @ src alias default to reactLibrary preset

### DIFF
--- a/packages/vite-config/index.test.ts
+++ b/packages/vite-config/index.test.ts
@@ -70,6 +70,15 @@ describe("vite-config", () => {
 			}
 		});
 
+		it("sets @ alias to <cwd>/src by default", async () => {
+			const config = await reactLibrary();
+			const alias = config.resolve?.alias;
+			const atAlias = Array.isArray(alias)
+				? alias.find((a) => a.find === "@")?.replacement
+				: (alias as Record<string, string>)?.["@"];
+			expect(atAlias).toContain("src");
+		});
+
 		it("merges overrides into the base config", async () => {
 			const config = await reactLibrary({ overrides: { publicDir: "public" } });
 			expect(config.publicDir).toBe("public");

--- a/packages/vite-config/presets/react-library.ts
+++ b/packages/vite-config/presets/react-library.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { mergeConfig, type UserConfig } from "vite";
 import { getPackageName } from "./get-package-name.js";
 
@@ -57,6 +58,11 @@ export async function reactLibrary({
 					},
 				},
 				sourcemap: true,
+			},
+			resolve: {
+				alias: {
+					"@": resolve(process.cwd(), "src"),
+				},
 			},
 		},
 		overrides


### PR DESCRIPTION
## Summary

- Adds `resolve.alias: { "@": resolve(process.cwd(), "src") }` as a default in the `reactLibrary` preset
- Uses `process.cwd()` (not `import.meta.url`) so the path resolves to the **consumer's** project root at Vite runtime, not the preset file's location
- `publicDir: "public"` is already Vite's default — no change needed there

## Consumer before / after

**Before:**
```ts
export default reactLibrary({
  name: "my-lib",
  overrides: {
    resolve: { alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) } },
  },
});
```

**After:**
```ts
export default reactLibrary({ name: "my-lib" });
```

## Test plan

- [x] 15 tests pass including new assertion that `@` alias resolves to a path containing `"src"`
- [x] `tsc --noEmit` clean
- [x] Build clean