### PR TITLE
feat(vitest-config): export coverage defaults object

### DIFF
--- a/packages/vitest-config/coverage.ts
+++ b/packages/vitest-config/coverage.ts
@@ -1,0 +1,8 @@
+import { coverageConfigDefaults } from "vitest/config";
+
+export const coverage = {
+	all: false,
+	exclude: [...coverageConfigDefaults.exclude] as string[],
+	provider: "v8" as const,
+	reporter: ["text", "lcov"] as string[],
+};

--- a/packages/vitest-config/index.test.ts
+++ b/packages/vitest-config/index.test.ts
@@ -6,7 +6,7 @@ vi.mock("@storybook/addon-vitest/vitest-plugin", () => ({
 	storybookTest: vi.fn(() => ({ name: "storybook-vitest-plugin" })),
 }));
 
-import { node, react, storybook } from "./index.js";
+import { coverage, node, react, storybook } from "./index.js";
 import { library } from "./bundles/library.js";
 
 describe("vitest-config — presets", () => {
@@ -35,6 +35,30 @@ describe("vitest-config — presets", () => {
 	it("presets accept option overrides", () => {
 		const config = node({ reporters: ["verbose"] });
 		expect(config.test?.reporters).toContain("verbose");
+	});
+});
+
+describe("vitest-config — coverage defaults", () => {
+	it("uses v8 provider", () => {
+		expect(coverage.provider).toBe("v8");
+	});
+
+	it("includes text and lcov reporters", () => {
+		expect(coverage.reporter).toContain("text");
+		expect(coverage.reporter).toContain("lcov");
+	});
+
+	it("sets all to false", () => {
+		expect(coverage.all).toBe(false);
+	});
+
+	it("expose an array of excludes", () => {
+		expect(Array.isArray(coverage.exclude)).toBe(true);
+	});
+
+	it("exclude is extensible", () => {
+		const extended = [...coverage.exclude, "**/handlers.*"];
+		expect(extended).toContain("**/handlers.*");
 	});
 });
 

--- a/packages/vitest-config/index.ts
+++ b/packages/vitest-config/index.ts
@@ -1,3 +1,4 @@
+export { coverage } from "./coverage.js";
 export { node } from "./presets/node.js";
 export { react } from "./presets/react.js";
 export { storybook } from "./presets/storybook.js";

--- a/packages/vitest-config/package.json
+++ b/packages/vitest-config/package.json
@@ -38,6 +38,11 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./coverage": {
+      "types": "./dist/coverage.d.ts",
+      "import": "./dist/coverage.js",
+      "default": "./dist/coverage.js"
+    },
     "./node": {
       "types": "./dist/presets/node.d.ts",
       "import": "./dist/presets/node.js",

--- a/packages/vitest-config/tsdown.config.ts
+++ b/packages/vitest-config/tsdown.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
 	entry: [
 		"index.ts",
+		"coverage.ts",
 		"presets/node.ts",
 		"presets/react.ts",
 		"presets/storybook.ts",


### PR DESCRIPTION
## Summary

Exports a `coverage` object from `@theholocron/vitest-config` (and `@theholocron/vitest-config/coverage`) containing the standard coverage defaults used across all projects:

```ts
export const coverage = {
  all: false,
  exclude: [...coverageConfigDefaults.exclude],
  provider: "v8",
  reporter: ["text", "lcov"],
};
```

Coverage lives at the root `test` level in vitest projects mode — it can't go in a preset (which returns a `UserProjectConfig`). This export lets consumers spread the defaults and add project-specific excludes:

```ts
import { coverage, react, storybook } from "@theholocron/vitest-config";

export default defineConfig(async () => ({
  test: {
    coverage: {
      ...coverage,
      exclude: [...coverage.exclude, "**/handlers.*", "**/*.{mock}.*"],
    },
    projects: [react({ name: "unit" }), await storybook(...)],
  },
}));
```

## Test plan

- [x] 20 tests pass including 5 new coverage assertions
- [x] `tsc --noEmit` clean
- [x] Build clean (18 output files)