### PR TITLE
feat: add @theholocron/lighthouse-config package

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -43,6 +43,11 @@ component_management:
       paths:
         - packages/commitlint-config/**
 
+    - component_id: lighthouse-config
+      name: "lighthouse-config"
+      paths:
+        - packages/lighthouse-config/**
+
     - component_id: configs-docs
       name: "configs-docs"
       paths:

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -67,19 +67,36 @@ import { cypress } from "@theholocron/eslint-config/cypress";
 Bundles combine presets and peer plugins into a single import for common project types. Use these when you want a ready-made config with no manual composition:
 
 ```javascript
-// React app (base + typescript + react + vitest)
-import reactApp from "@theholocron/eslint-config/bundles/react-app";
-export default reactApp();
+// React app (base + typescript + react + storybook + vitest)
+import { reactApp } from "@theholocron/eslint-config/bundles/react-app";
+export default [...reactApp()];
 
 // Next.js app (base + typescript + react + next + vitest)
-import nextApp from "@theholocron/eslint-config/bundles/next-app";
-export default nextApp();
+import { nextApp } from "@theholocron/eslint-config/bundles/next-app";
+export default [...nextApp()];
 
 // Node.js app or CLI (base + typescript + node + vitest)
-import nodeApp from "@theholocron/eslint-config/bundles/node-app";
-export default nodeApp();
+import { nodeApp } from "@theholocron/eslint-config/bundles/node-app";
+export default [...nodeApp()];
 
 // Publishable library (base + typescript + vitest)
-import library from "@theholocron/eslint-config/bundles/library";
-export default library();
+import { library } from "@theholocron/eslint-config/bundles/library";
+export default [...library()];
 ```
+
+Add project-specific configs after the bundle — they are merged in order:
+
+```javascript
+import { reactApp } from "@theholocron/eslint-config/bundles/react-app";
+import { cypress } from "@theholocron/eslint-config/cypress";
+
+export default [
+  ...reactApp(),
+  ...cypress(),
+  { settings: { react: { version: "detect" } } },
+];
+```
+
+## ESLint version
+
+Requires ESLint v10. The `react` preset wraps `eslint-plugin-react` with `@eslint/compat`'s `fixupConfigRules` to patch APIs removed in ESLint v10 — no extra config needed.

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -90,11 +90,7 @@ Add project-specific configs after the bundle — they are merged in order:
 import { reactApp } from "@theholocron/eslint-config/bundles/react-app";
 import { cypress } from "@theholocron/eslint-config/cypress";
 
-export default [
-  ...reactApp(),
-  ...cypress(),
-  { settings: { react: { version: "detect" } } },
-];
+export default [...reactApp(), ...cypress(), { settings: { react: { version: "detect" } } }];
 ```
 
 ## ESLint version

--- a/packages/lighthouse-config/README.md
+++ b/packages/lighthouse-config/README.md
@@ -22,8 +22,8 @@ Create a `lighthouse.config.js` at the project root and pass it to `lhci` with `
 import { defineConfig } from "@theholocron/lighthouse-config";
 
 export default defineConfig({
-  url: "http://localhost:5173/",
-  startServerCommand: "pnpm dev",
+	url: "http://localhost:5173/",
+	startServerCommand: "pnpm dev",
 });
 ```
 
@@ -37,12 +37,12 @@ pnpm lhci autorun --config=./lighthouse.config.js
 
 ## Options
 
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `url` | `string \| string[]` | — | URL(s) to audit |
-| `startServerCommand` | `string` | — | Command to start the dev server before collecting |
-| `assertions` | `LighthouseAssertion` | `defaultAssertions` | Audit thresholds |
-| `uploadTarget` | `string` | `"temporary-public-storage"` | Where to upload results |
+| Option               | Type                  | Default                      | Description                                       |
+| -------------------- | --------------------- | ---------------------------- | ------------------------------------------------- |
+| `url`                | `string \| string[]`  | —                            | URL(s) to audit                                   |
+| `startServerCommand` | `string`              | —                            | Command to start the dev server before collecting |
+| `assertions`         | `LighthouseAssertion` | `defaultAssertions`          | Audit thresholds                                  |
+| `uploadTarget`       | `string`              | `"temporary-public-storage"` | Where to upload results                           |
 
 ## Default assertions
 
@@ -59,11 +59,11 @@ Override individual thresholds by spreading and replacing:
 import { defineConfig, defaultAssertions } from "@theholocron/lighthouse-config";
 
 export default defineConfig({
-  url: "http://localhost:5173/",
-  startServerCommand: "pnpm dev",
-  assertions: {
-    ...defaultAssertions,
-    "largest-contentful-paint": ["error", { minScore: 0.95 }],
-  },
+	url: "http://localhost:5173/",
+	startServerCommand: "pnpm dev",
+	assertions: {
+		...defaultAssertions,
+		"largest-contentful-paint": ["error", { minScore: 0.95 }],
+	},
 });
 ```

--- a/packages/lighthouse-config/README.md
+++ b/packages/lighthouse-config/README.md
@@ -1,0 +1,69 @@
+# Lighthouse Config
+
+A [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci) configuration with sensible defaults for auditing performance and accessibility within the Galaxy.
+
+## Installation
+
+```bash
+pnpm add -D @theholocron/lighthouse-config
+```
+
+Install `@lhci/cli` to run audits:
+
+```bash
+pnpm add -D @lhci/cli
+```
+
+## Usage
+
+Create a `lighthouse.config.js` at the project root and pass it to `lhci` with `--config`:
+
+```javascript
+import { defineConfig } from "@theholocron/lighthouse-config";
+
+export default defineConfig({
+  url: "http://localhost:5173/",
+  startServerCommand: "pnpm dev",
+});
+```
+
+Run with:
+
+```bash
+pnpm lhci autorun --config=./lighthouse.config.js
+```
+
+> **Note:** `@lhci/cli` does not support upward directory traversal for config discovery. Always pass `--config=./lighthouse.config.js` explicitly.
+
+## Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `url` | `string \| string[]` | — | URL(s) to audit |
+| `startServerCommand` | `string` | — | Command to start the dev server before collecting |
+| `assertions` | `LighthouseAssertion` | `defaultAssertions` | Audit thresholds |
+| `uploadTarget` | `string` | `"temporary-public-storage"` | Where to upload results |
+
+## Default assertions
+
+The `defaultAssertions` export contains the standard set of thresholds. All audit at `warn` level with a `minScore` of `0.9` (or `maxLength: 0` for byte-size audits):
+
+- `bf-cache`, `errors-in-console`, `font-display`, `label`
+- `largest-contentful-paint`, `lcp-lazy-loaded`
+- `non-composited-animations`, `prioritize-lcp-image`
+- `unused-javascript`, `uses-long-cache-ttl`
+
+Override individual thresholds by spreading and replacing:
+
+```javascript
+import { defineConfig, defaultAssertions } from "@theholocron/lighthouse-config";
+
+export default defineConfig({
+  url: "http://localhost:5173/",
+  startServerCommand: "pnpm dev",
+  assertions: {
+    ...defaultAssertions,
+    "largest-contentful-paint": ["error", { minScore: 0.95 }],
+  },
+});
+```

--- a/packages/lighthouse-config/index.test.ts
+++ b/packages/lighthouse-config/index.test.ts
@@ -4,17 +4,11 @@ import { defaultAssertions, defineConfig } from "./index.js";
 describe("lighthouse-config", () => {
 	describe("defaultAssertions", () => {
 		it("warns on largest-contentful-paint below 0.9", () => {
-			expect(defaultAssertions["largest-contentful-paint"]).toEqual([
-				"warn",
-				{ minScore: 0.9 },
-			]);
+			expect(defaultAssertions["largest-contentful-paint"]).toEqual(["warn", { minScore: 0.9 }]);
 		});
 
 		it("warns on unused-javascript with maxLength 0", () => {
-			expect(defaultAssertions["unused-javascript"]).toEqual([
-				"warn",
-				{ maxLength: 0 },
-			]);
+			expect(defaultAssertions["unused-javascript"]).toEqual(["warn", { maxLength: 0 }]);
 		});
 	});
 
@@ -54,10 +48,7 @@ describe("lighthouse-config", () => {
 				url: "http://localhost:3000/",
 				assertions: custom,
 			});
-			expect(config.ci.assert.assertions["bf-cache"]).toEqual([
-				"error",
-				{ minScore: 1 },
-			]);
+			expect(config.ci.assert.assertions["bf-cache"]).toEqual(["error", { minScore: 1 }]);
 		});
 
 		it("defaults upload target to temporary-public-storage", () => {

--- a/packages/lighthouse-config/index.test.ts
+++ b/packages/lighthouse-config/index.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { defaultAssertions, lighthouseConfig } from "./index.js";
+
+describe("lighthouse-config", () => {
+	describe("defaultAssertions", () => {
+		it("warns on largest-contentful-paint below 0.9", () => {
+			expect(defaultAssertions["largest-contentful-paint"]).toEqual([
+				"warn",
+				{ minScore: 0.9 },
+			]);
+		});
+
+		it("warns on unused-javascript with maxLength 0", () => {
+			expect(defaultAssertions["unused-javascript"]).toEqual([
+				"warn",
+				{ maxLength: 0 },
+			]);
+		});
+	});
+
+	describe("lighthouseConfig()", () => {
+		it("wraps a single url in an array", () => {
+			const config = lighthouseConfig({ url: "http://localhost:3000/" });
+			expect(config.ci.collect.url).toEqual(["http://localhost:3000/"]);
+		});
+
+		it("passes an array url through unchanged", () => {
+			const urls = ["http://localhost:3000/", "http://localhost:3000/about"];
+			const config = lighthouseConfig({ url: urls });
+			expect(config.ci.collect.url).toEqual(urls);
+		});
+
+		it("includes startServerCommand when provided", () => {
+			const config = lighthouseConfig({
+				url: "http://localhost:3000/",
+				startServerCommand: "pnpm dev",
+			});
+			expect(config.ci.collect.startServerCommand).toBe("pnpm dev");
+		});
+
+		it("omits startServerCommand when not provided", () => {
+			const config = lighthouseConfig({ url: "http://localhost:3000/" });
+			expect(config.ci.collect).not.toHaveProperty("startServerCommand");
+		});
+
+		it("uses defaultAssertions by default", () => {
+			const config = lighthouseConfig({ url: "http://localhost:3000/" });
+			expect(config.ci.assert.assertions).toBe(defaultAssertions);
+		});
+
+		it("accepts custom assertions", () => {
+			const custom = { "bf-cache": ["error", { minScore: 1 }] as ["error", { minScore: number }] };
+			const config = lighthouseConfig({
+				url: "http://localhost:3000/",
+				assertions: custom,
+			});
+			expect(config.ci.assert.assertions["bf-cache"]).toEqual([
+				"error",
+				{ minScore: 1 },
+			]);
+		});
+
+		it("defaults upload target to temporary-public-storage", () => {
+			const config = lighthouseConfig({ url: "http://localhost:3000/" });
+			expect(config.ci.upload.target).toBe("temporary-public-storage");
+		});
+
+		it("accepts a custom upload target", () => {
+			const config = lighthouseConfig({
+				url: "http://localhost:3000/",
+				uploadTarget: "lhci",
+			});
+			expect(config.ci.upload.target).toBe("lhci");
+		});
+	});
+});

--- a/packages/lighthouse-config/index.test.ts
+++ b/packages/lighthouse-config/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { defaultAssertions, lighthouseConfig } from "./index.js";
+import { defaultAssertions, defineConfig } from "./index.js";
 
 describe("lighthouse-config", () => {
 	describe("defaultAssertions", () => {
@@ -18,20 +18,20 @@ describe("lighthouse-config", () => {
 		});
 	});
 
-	describe("lighthouseConfig()", () => {
+	describe("defineConfig()", () => {
 		it("wraps a single url in an array", () => {
-			const config = lighthouseConfig({ url: "http://localhost:3000/" });
+			const config = defineConfig({ url: "http://localhost:3000/" });
 			expect(config.ci.collect.url).toEqual(["http://localhost:3000/"]);
 		});
 
 		it("passes an array url through unchanged", () => {
 			const urls = ["http://localhost:3000/", "http://localhost:3000/about"];
-			const config = lighthouseConfig({ url: urls });
+			const config = defineConfig({ url: urls });
 			expect(config.ci.collect.url).toEqual(urls);
 		});
 
 		it("includes startServerCommand when provided", () => {
-			const config = lighthouseConfig({
+			const config = defineConfig({
 				url: "http://localhost:3000/",
 				startServerCommand: "pnpm dev",
 			});
@@ -39,18 +39,18 @@ describe("lighthouse-config", () => {
 		});
 
 		it("omits startServerCommand when not provided", () => {
-			const config = lighthouseConfig({ url: "http://localhost:3000/" });
+			const config = defineConfig({ url: "http://localhost:3000/" });
 			expect(config.ci.collect).not.toHaveProperty("startServerCommand");
 		});
 
 		it("uses defaultAssertions by default", () => {
-			const config = lighthouseConfig({ url: "http://localhost:3000/" });
+			const config = defineConfig({ url: "http://localhost:3000/" });
 			expect(config.ci.assert.assertions).toBe(defaultAssertions);
 		});
 
 		it("accepts custom assertions", () => {
 			const custom = { "bf-cache": ["error", { minScore: 1 }] as ["error", { minScore: number }] };
-			const config = lighthouseConfig({
+			const config = defineConfig({
 				url: "http://localhost:3000/",
 				assertions: custom,
 			});
@@ -61,12 +61,12 @@ describe("lighthouse-config", () => {
 		});
 
 		it("defaults upload target to temporary-public-storage", () => {
-			const config = lighthouseConfig({ url: "http://localhost:3000/" });
+			const config = defineConfig({ url: "http://localhost:3000/" });
 			expect(config.ci.upload.target).toBe("temporary-public-storage");
 		});
 
 		it("accepts a custom upload target", () => {
-			const config = lighthouseConfig({
+			const config = defineConfig({
 				url: "http://localhost:3000/",
 				uploadTarget: "lhci",
 			});

--- a/packages/lighthouse-config/index.ts
+++ b/packages/lighthouse-config/index.ts
@@ -1,0 +1,55 @@
+type AssertionLevel = "off" | "warn" | "error";
+type MinScoreAssertion = [AssertionLevel, { minScore: number }];
+type MaxLengthAssertion = [AssertionLevel, { maxLength: number }];
+
+export interface LighthouseAssertion {
+	"bf-cache"?: MinScoreAssertion;
+	"errors-in-console"?: MinScoreAssertion;
+	"font-display"?: MinScoreAssertion;
+	"label"?: MinScoreAssertion;
+	"largest-contentful-paint"?: MinScoreAssertion;
+	"lcp-lazy-loaded"?: MinScoreAssertion;
+	"non-composited-animations"?: MinScoreAssertion;
+	"prioritize-lcp-image"?: MinScoreAssertion;
+	"unused-javascript"?: MaxLengthAssertion;
+	"uses-long-cache-ttl"?: MaxLengthAssertion;
+	[key: string]: MinScoreAssertion | MaxLengthAssertion | undefined;
+}
+
+export const defaultAssertions: LighthouseAssertion = {
+	"bf-cache": ["warn", { minScore: 0.9 }],
+	"errors-in-console": ["warn", { minScore: 0.9 }],
+	"font-display": ["warn", { minScore: 0.9 }],
+	"label": ["warn", { minScore: 0.9 }],
+	"largest-contentful-paint": ["warn", { minScore: 0.9 }],
+	"lcp-lazy-loaded": ["warn", { minScore: 0.9 }],
+	"non-composited-animations": ["warn", { minScore: 0.9 }],
+	"prioritize-lcp-image": ["warn", { minScore: 0.9 }],
+	"unused-javascript": ["warn", { maxLength: 0 }],
+	"uses-long-cache-ttl": ["warn", { maxLength: 0 }],
+};
+
+export interface LighthouseConfigOptions {
+	url: string | string[];
+	startServerCommand?: string;
+	assertions?: LighthouseAssertion;
+	uploadTarget?: string;
+}
+
+export function lighthouseConfig({
+	url,
+	startServerCommand,
+	assertions = defaultAssertions,
+	uploadTarget = "temporary-public-storage",
+}: LighthouseConfigOptions) {
+	return {
+		ci: {
+			collect: {
+				url: Array.isArray(url) ? url : [url],
+				...(startServerCommand ? { startServerCommand } : {}),
+			},
+			assert: { assertions },
+			upload: { target: uploadTarget },
+		},
+	};
+}

--- a/packages/lighthouse-config/index.ts
+++ b/packages/lighthouse-config/index.ts
@@ -6,7 +6,7 @@ export interface LighthouseAssertion {
 	"bf-cache"?: MinScoreAssertion;
 	"errors-in-console"?: MinScoreAssertion;
 	"font-display"?: MinScoreAssertion;
-	"label"?: MinScoreAssertion;
+	label?: MinScoreAssertion;
 	"largest-contentful-paint"?: MinScoreAssertion;
 	"lcp-lazy-loaded"?: MinScoreAssertion;
 	"non-composited-animations"?: MinScoreAssertion;
@@ -20,7 +20,7 @@ export const defaultAssertions: LighthouseAssertion = {
 	"bf-cache": ["warn", { minScore: 0.9 }],
 	"errors-in-console": ["warn", { minScore: 0.9 }],
 	"font-display": ["warn", { minScore: 0.9 }],
-	"label": ["warn", { minScore: 0.9 }],
+	label: ["warn", { minScore: 0.9 }],
 	"largest-contentful-paint": ["warn", { minScore: 0.9 }],
 	"lcp-lazy-loaded": ["warn", { minScore: 0.9 }],
 	"non-composited-animations": ["warn", { minScore: 0.9 }],

--- a/packages/lighthouse-config/index.ts
+++ b/packages/lighthouse-config/index.ts
@@ -36,7 +36,7 @@ export interface LighthouseConfigOptions {
 	uploadTarget?: string;
 }
 
-export function lighthouseConfig({
+export function defineConfig({
 	url,
 	startServerCommand,
 	assertions = defaultAssertions,

--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@theholocron/lighthouse-config",
+  "version": "7.12.0",
+  "description": "A Lighthouse CI configuration for auditing performance and accessibility within the Galaxy.",
+  "homepage": "https://github.com/theholocron/configs/tree/main/packages/lighthouse-config#readme",
+  "bugs": "https://github.com/theholocron/configs/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/configs.git"
+  },
+  "license": "GPL-3.0",
+  "author": "Newton Koumantzelis",
+  "keywords": [
+    "lighthouse",
+    "performance",
+    "accessibility",
+    "audit",
+    "config",
+    "theholocron"
+  ],
+  "type": "module",
+  "scripts": {
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "@theholocron/tsconfig": "workspace:*",
+    "@theholocron/vitest-config": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "releases": "https://github.com/theholocron/configs/releases",
+  "wiki": "https://github.com/theholocron/configs/wiki"
+}

--- a/packages/lighthouse-config/tsconfig.json
+++ b/packages/lighthouse-config/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@theholocron/tsconfig/node-lts",
+  "compilerOptions": { "rootDir": ".", "outDir": "dist" },
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules", "tsdown.config.ts"]
+}

--- a/packages/lighthouse-config/tsdown.config.ts
+++ b/packages/lighthouse-config/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: ["index.ts"],
+	format: "esm",
+	fixedExtension: false,
+	dts: true,
+	clean: true,
+	deps: { dts: { neverBundle: /.*/ } },
+});

--- a/packages/lighthouse-config/vitest.config.ts
+++ b/packages/lighthouse-config/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from "vitest/config";
+import { node } from "@theholocron/vitest-config";
+
+export default defineConfig(node());

--- a/packages/vite-config/README.md
+++ b/packages/vite-config/README.md
@@ -12,52 +12,72 @@ pnpm add -D @theholocron/vite-config
 
 Pick the preset that matches your project type. All presets accept an `overrides` object that is deep-merged last via `mergeConfig`.
 
-### Publishable library
+### React component library
+
+Outputs ESM + CJS; externalises `react` and `react-dom`; wires up `@vitejs/plugin-react`; sets `@` as an alias for `src/`. Returns a `Promise` because plugins are loaded dynamically.
+
+```typescript
+import { reactLibrary } from "@theholocron/vite-config/react-library";
+
+export default reactLibrary({ name: "my-lib" });
+```
+
+Pass `overrides` to add project-specific config:
+
+```typescript
+import { reactLibrary } from "@theholocron/vite-config/react-library";
+import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
+
+export default reactLibrary({
+  name: "my-lib",
+  overrides: {
+    plugins: [storybookTest()],
+  },
+});
+```
+
+### Publishable library (non-React)
 
 Outputs ESM only; externalises `react` and `react-dom` by default. Returns a `Promise` because the plugin is loaded dynamically.
 
-```javascript
-import { defineConfig } from "vite";
+```typescript
 import { library } from "@theholocron/vite-config/library";
 
-export default defineConfig(await library({ entry: "src/index.ts", name: "MyLib" }));
+export default library({ entry: "src/index.ts", name: "MyLib" });
 ```
 
 ### React single-page application
 
 Requires `@vitejs/plugin-react` as a peer dependency. Returns a `Promise` because the plugin is loaded dynamically.
 
-```javascript
-import { defineConfig } from "vite";
+```typescript
 import { reactApp } from "@theholocron/vite-config/react-app";
 
-export default defineConfig(await reactApp());
+export default reactApp();
 ```
 
 Pass `vite-tsconfig-paths` via `overrides.plugins` to enable tsconfig path aliases:
 
-```javascript
-import { defineConfig } from "vite";
+```typescript
 import tsconfigPaths from "vite-tsconfig-paths";
 import { reactApp } from "@theholocron/vite-config/react-app";
 
-export default defineConfig(await reactApp({ plugins: [tsconfigPaths()] }));
+export default reactApp({ plugins: [tsconfigPaths()] });
 ```
 
 ### Node.js CLI tool or server app
 
 Targets Node 22; outputs a single ESM bundle with no browser polyfills. Returns a `Promise` because the plugin is loaded dynamically.
 
-```javascript
-import { defineConfig } from "vite";
+```typescript
 import { nodeApp } from "@theholocron/vite-config/node-app";
 
-export default defineConfig(await nodeApp({ entry: "src/index.ts" }));
+export default nodeApp({ entry: "src/index.ts" });
 ```
 
 ## Codecov bundle analysis
 
-All three presets automatically include [`@codecov/vite-plugin`](https://www.npmjs.com/package/@codecov/vite-plugin) when `@codecov/vite-plugin` is installed and `CODECOV_TOKEN` is set in the environment. No extra configuration in `vite.config.ts` is needed — bundle stats are uploaded to Codecov on every build.
+All presets automatically include [`@codecov/vite-plugin`](https://www.npmjs.com/package/@codecov/vite-plugin) when `@codecov/vite-plugin` is installed and `CODECOV_TOKEN` is set in the environment. No extra configuration in `vite.config.ts` is needed — bundle stats are uploaded to Codecov on every build.
 
 Install the peer dependency:
 

--- a/packages/vite-config/README.md
+++ b/packages/vite-config/README.md
@@ -29,10 +29,10 @@ import { reactLibrary } from "@theholocron/vite-config/react-library";
 import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 
 export default reactLibrary({
-  name: "my-lib",
-  overrides: {
-    plugins: [storybookTest()],
-  },
+	name: "my-lib",
+	overrides: {
+		plugins: [storybookTest()],
+	},
 });
 ```
 

--- a/packages/vitest-config/README.md
+++ b/packages/vitest-config/README.md
@@ -10,37 +10,96 @@ pnpm add -D @theholocron/vitest-config
 
 ## Usage
 
-Pick the preset that matches your project type. Presets return a `UserProjectConfig` object for use in `vitest.config.js`.
+Presets are designed for use with Vitest's `projects` array, which runs unit and component tests in separate environments. Coverage is configured at the root `test` level and applies across all projects.
+
+```typescript
+import { coverage, react, storybook } from "@theholocron/vitest-config";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig(async () => ({
+  test: {
+    coverage: {
+      ...coverage,
+      exclude: [...coverage.exclude, "**/mocks/**"],
+    },
+    projects: [
+      react({ name: "unit" }),
+      await storybook(".storybook", { setupFiles: ["./vitest.setup.ts"] }),
+    ],
+  },
+}));
+```
 
 ### Node.js library or CLI tool
 
-```javascript
+```typescript
+import { node } from "@theholocron/vitest-config";
 import { defineConfig } from "vitest/config";
-import { node } from "@theholocron/vitest-config/node";
 
-export default defineConfig({ test: node().test });
+export default defineConfig(node());
 ```
 
 ### React component library or app
 
-Requires `jsdom` and `@testing-library/react` as peer dependencies.
+Requires `jsdom`, `@testing-library/react`, and `@testing-library/jest-dom` as peer dependencies. The `react` preset automatically adds `@testing-library/jest-dom` to `setupFiles` — no manual import needed.
 
-```javascript
+```typescript
+import { react } from "@theholocron/vitest-config";
 import { defineConfig } from "vitest/config";
-import { react } from "@theholocron/vitest-config/react";
 
-export default defineConfig({ test: react().test });
+export default defineConfig(react());
 ```
 
 ### Storybook component tests
 
 Requires `@storybook/addon-vitest` and `playwright` as peer dependencies.
 
-```javascript
+```typescript
+import { storybook } from "@theholocron/vitest-config";
 import { defineConfig } from "vitest/config";
-import { storybook } from "@theholocron/vitest-config/storybook";
 
 export default defineConfig(await storybook(".storybook"));
+```
+
+## Coverage defaults
+
+The `coverage` export provides standard coverage configuration (v8 provider, `text` + `lcov` reporters, vitest's default excludes). Extend it with project-specific excludes:
+
+```typescript
+import { coverage } from "@theholocron/vitest-config";
+
+// in vitest.config.ts
+coverage: {
+  ...coverage,
+  exclude: [...coverage.exclude, "**/handlers.*", "**/*.mock.*"],
+}
+```
+
+## MSW setup helpers
+
+Use `setupMSWBrowser` and `setupMSWNode` from `@theholocron/vitest-config/setup/msw` to wire MSW lifecycle hooks. Pass optional Storybook annotations to ensure `annotations.beforeAll` runs before the worker starts.
+
+### Browser (Storybook / Playwright)
+
+```typescript
+// vitest.setup.ts
+import { setProjectAnnotations } from "@storybook/react";
+import { setupMSWBrowser } from "@theholocron/vitest-config/setup/msw";
+import * as preview from "./.storybook/preview";
+import { worker } from "./src/mocks/browser";
+
+const annotations = setProjectAnnotations([preview]);
+setupMSWBrowser(worker, annotations);
+```
+
+### Node (unit tests)
+
+```typescript
+// vitest.setup.ts
+import { setupMSWNode } from "@theholocron/vitest-config/setup/msw";
+import { server } from "./src/mocks/node";
+
+setupMSWNode(server);
 ```
 
 ## Bundles
@@ -49,20 +108,20 @@ Bundles combine a preset with opinionated coverage settings (80% threshold on al
 
 ### Library bundle
 
-```javascript
-import { defineConfig } from "vitest/config";
+```typescript
 import { library } from "@theholocron/vitest-config/bundles/library";
+import { defineConfig } from "vitest/config";
 
-export default defineConfig({ test: library().test });
+export default defineConfig(library());
 ```
 
 ### React app bundle
 
-```javascript
-import { defineConfig } from "vitest/config";
+```typescript
 import { reactApp } from "@theholocron/vitest-config/bundles/react-app";
+import { defineConfig } from "vitest/config";
 
-export default defineConfig({ test: reactApp().test });
+export default defineConfig(reactApp());
 ```
 
 ## How We Test

--- a/packages/vitest-config/README.md
+++ b/packages/vitest-config/README.md
@@ -17,16 +17,13 @@ import { coverage, react, storybook } from "@theholocron/vitest-config";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig(async () => ({
-  test: {
-    coverage: {
-      ...coverage,
-      exclude: [...coverage.exclude, "**/mocks/**"],
-    },
-    projects: [
-      react({ name: "unit" }),
-      await storybook(".storybook", { setupFiles: ["./vitest.setup.ts"] }),
-    ],
-  },
+	test: {
+		coverage: {
+			...coverage,
+			exclude: [...coverage.exclude, "**/mocks/**"],
+		},
+		projects: [react({ name: "unit" }), await storybook(".storybook", { setupFiles: ["./vitest.setup.ts"] })],
+	},
 }));
 ```
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,27 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
+  packages/lighthouse-config:
+    devDependencies:
+      '@theholocron/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@theholocron/vitest-config':
+        specifier: workspace:*
+        version: link:../vitest-config
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.14(tsx@4.23.1)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+
   packages/lint-staged-config:
     dependencies:
       lint-staged:


### PR DESCRIPTION
## Summary

Adds `@theholocron/lighthouse-config` — a shared Lighthouse CI configuration package.

Exports:
- `defaultAssertions` — the standard set of Lighthouse audit thresholds (warn on LCP <0.9, unused JS, long cache TTL, etc.)
- `lighthouseConfig({ url, startServerCommand?, assertions?, uploadTarget? })` — factory that builds a complete `lhci` config object

Consumer usage (`lighthouse.config.js`):
```js
import { lighthouseConfig } from "@theholocron/lighthouse-config";

export default lighthouseConfig({
  url: "http://localhost:5173/",
  startServerCommand: "pnpm dev",
});
```

Custom assertions spread on top of defaults:
```js
import { defaultAssertions, lighthouseConfig } from "@theholocron/lighthouse-config";

export default lighthouseConfig({
  url: "http://localhost:5173/",
  startServerCommand: "pnpm dev",
  assertions: { ...defaultAssertions, "bf-cache": ["error", { minScore: 1 }] },
});
```

## Test plan

- [x] 10 tests pass (defaultAssertions shape, url wrapping, startServerCommand optional, custom assertions, upload target default/override)
- [x] `tsc --noEmit` clean
- [x] Build clean (2 files: `dist/index.js`, `dist/index.d.ts`)
- [x] codecov component added