### PR TITLE
docs: update READMEs for vitest-config, vite-config, and eslint-config

### DIFF
--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -67,19 +67,36 @@ import { cypress } from "@theholocron/eslint-config/cypress";
 Bundles combine presets and peer plugins into a single import for common project types. Use these when you want a ready-made config with no manual composition:
 
 ```javascript
-// React app (base + typescript + react + vitest)
-import reactApp from "@theholocron/eslint-config/bundles/react-app";
-export default reactApp();
+// React app (base + typescript + react + storybook + vitest)
+import { reactApp } from "@theholocron/eslint-config/bundles/react-app";
+export default [...reactApp()];
 
 // Next.js app (base + typescript + react + next + vitest)
-import nextApp from "@theholocron/eslint-config/bundles/next-app";
-export default nextApp();
+import { nextApp } from "@theholocron/eslint-config/bundles/next-app";
+export default [...nextApp()];
 
 // Node.js app or CLI (base + typescript + node + vitest)
-import nodeApp from "@theholocron/eslint-config/bundles/node-app";
-export default nodeApp();
+import { nodeApp } from "@theholocron/eslint-config/bundles/node-app";
+export default [...nodeApp()];
 
 // Publishable library (base + typescript + vitest)
-import library from "@theholocron/eslint-config/bundles/library";
-export default library();
+import { library } from "@theholocron/eslint-config/bundles/library";
+export default [...library()];
 ```
+
+Add project-specific configs after the bundle — they are merged in order:
+
+```javascript
+import { reactApp } from "@theholocron/eslint-config/bundles/react-app";
+import { cypress } from "@theholocron/eslint-config/cypress";
+
+export default [
+  ...reactApp(),
+  ...cypress(),
+  { settings: { react: { version: "detect" } } },
+];
+```
+
+## ESLint version
+
+Requires ESLint v10. The `react` preset wraps `eslint-plugin-react` with `@eslint/compat`'s `fixupConfigRules` to patch APIs removed in ESLint v10 — no extra config needed.

--- a/packages/vite-config/README.md
+++ b/packages/vite-config/README.md
@@ -12,52 +12,72 @@ pnpm add -D @theholocron/vite-config
 
 Pick the preset that matches your project type. All presets accept an `overrides` object that is deep-merged last via `mergeConfig`.
 
-### Publishable library
+### React component library
+
+Outputs ESM + CJS; externalises `react` and `react-dom`; wires up `@vitejs/plugin-react`; sets `@` as an alias for `src/`. Returns a `Promise` because plugins are loaded dynamically.
+
+```typescript
+import { reactLibrary } from "@theholocron/vite-config/react-library";
+
+export default reactLibrary({ name: "my-lib" });
+```
+
+Pass `overrides` to add project-specific config:
+
+```typescript
+import { reactLibrary } from "@theholocron/vite-config/react-library";
+import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
+
+export default reactLibrary({
+  name: "my-lib",
+  overrides: {
+    plugins: [storybookTest()],
+  },
+});
+```
+
+### Publishable library (non-React)
 
 Outputs ESM only; externalises `react` and `react-dom` by default. Returns a `Promise` because the plugin is loaded dynamically.
 
-```javascript
-import { defineConfig } from "vite";
+```typescript
 import { library } from "@theholocron/vite-config/library";
 
-export default defineConfig(await library({ entry: "src/index.ts", name: "MyLib" }));
+export default library({ entry: "src/index.ts", name: "MyLib" });
 ```
 
 ### React single-page application
 
 Requires `@vitejs/plugin-react` as a peer dependency. Returns a `Promise` because the plugin is loaded dynamically.
 
-```javascript
-import { defineConfig } from "vite";
+```typescript
 import { reactApp } from "@theholocron/vite-config/react-app";
 
-export default defineConfig(await reactApp());
+export default reactApp();
 ```
 
 Pass `vite-tsconfig-paths` via `overrides.plugins` to enable tsconfig path aliases:
 
-```javascript
-import { defineConfig } from "vite";
+```typescript
 import tsconfigPaths from "vite-tsconfig-paths";
 import { reactApp } from "@theholocron/vite-config/react-app";
 
-export default defineConfig(await reactApp({ plugins: [tsconfigPaths()] }));
+export default reactApp({ plugins: [tsconfigPaths()] });
 ```
 
 ### Node.js CLI tool or server app
 
 Targets Node 22; outputs a single ESM bundle with no browser polyfills. Returns a `Promise` because the plugin is loaded dynamically.
 
-```javascript
-import { defineConfig } from "vite";
+```typescript
 import { nodeApp } from "@theholocron/vite-config/node-app";
 
-export default defineConfig(await nodeApp({ entry: "src/index.ts" }));
+export default nodeApp({ entry: "src/index.ts" });
 ```
 
 ## Codecov bundle analysis
 
-All three presets automatically include [`@codecov/vite-plugin`](https://www.npmjs.com/package/@codecov/vite-plugin) when `@codecov/vite-plugin` is installed and `CODECOV_TOKEN` is set in the environment. No extra configuration in `vite.config.ts` is needed — bundle stats are uploaded to Codecov on every build.
+All presets automatically include [`@codecov/vite-plugin`](https://www.npmjs.com/package/@codecov/vite-plugin) when `@codecov/vite-plugin` is installed and `CODECOV_TOKEN` is set in the environment. No extra configuration in `vite.config.ts` is needed — bundle stats are uploaded to Codecov on every build.
 
 Install the peer dependency:
 

--- a/packages/vitest-config/README.md
+++ b/packages/vitest-config/README.md
@@ -10,37 +10,96 @@ pnpm add -D @theholocron/vitest-config
 
 ## Usage
 
-Pick the preset that matches your project type. Presets return a `UserProjectConfig` object for use in `vitest.config.js`.
+Presets are designed for use with Vitest's `projects` array, which runs unit and component tests in separate environments. Coverage is configured at the root `test` level and applies across all projects.
+
+```typescript
+import { coverage, react, storybook } from "@theholocron/vitest-config";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig(async () => ({
+  test: {
+    coverage: {
+      ...coverage,
+      exclude: [...coverage.exclude, "**/mocks/**"],
+    },
+    projects: [
+      react({ name: "unit" }),
+      await storybook(".storybook", { setupFiles: ["./vitest.setup.ts"] }),
+    ],
+  },
+}));
+```
 
 ### Node.js library or CLI tool
 
-```javascript
+```typescript
+import { node } from "@theholocron/vitest-config";
 import { defineConfig } from "vitest/config";
-import { node } from "@theholocron/vitest-config/node";
 
-export default defineConfig({ test: node().test });
+export default defineConfig(node());
 ```
 
 ### React component library or app
 
-Requires `jsdom` and `@testing-library/react` as peer dependencies.
+Requires `jsdom`, `@testing-library/react`, and `@testing-library/jest-dom` as peer dependencies. The `react` preset automatically adds `@testing-library/jest-dom` to `setupFiles` — no manual import needed.
 
-```javascript
+```typescript
+import { react } from "@theholocron/vitest-config";
 import { defineConfig } from "vitest/config";
-import { react } from "@theholocron/vitest-config/react";
 
-export default defineConfig({ test: react().test });
+export default defineConfig(react());
 ```
 
 ### Storybook component tests
 
 Requires `@storybook/addon-vitest` and `playwright` as peer dependencies.
 
-```javascript
+```typescript
+import { storybook } from "@theholocron/vitest-config";
 import { defineConfig } from "vitest/config";
-import { storybook } from "@theholocron/vitest-config/storybook";
 
 export default defineConfig(await storybook(".storybook"));
+```
+
+## Coverage defaults
+
+The `coverage` export provides standard coverage configuration (v8 provider, `text` + `lcov` reporters, vitest's default excludes). Extend it with project-specific excludes:
+
+```typescript
+import { coverage } from "@theholocron/vitest-config";
+
+// in vitest.config.ts
+coverage: {
+  ...coverage,
+  exclude: [...coverage.exclude, "**/handlers.*", "**/*.mock.*"],
+}
+```
+
+## MSW setup helpers
+
+Use `setupMSWBrowser` and `setupMSWNode` from `@theholocron/vitest-config/setup/msw` to wire MSW lifecycle hooks. Pass optional Storybook annotations to ensure `annotations.beforeAll` runs before the worker starts.
+
+### Browser (Storybook / Playwright)
+
+```typescript
+// vitest.setup.ts
+import { setProjectAnnotations } from "@storybook/react";
+import { setupMSWBrowser } from "@theholocron/vitest-config/setup/msw";
+import * as preview from "./.storybook/preview";
+import { worker } from "./src/mocks/browser";
+
+const annotations = setProjectAnnotations([preview]);
+setupMSWBrowser(worker, annotations);
+```
+
+### Node (unit tests)
+
+```typescript
+// vitest.setup.ts
+import { setupMSWNode } from "@theholocron/vitest-config/setup/msw";
+import { server } from "./src/mocks/node";
+
+setupMSWNode(server);
 ```
 
 ## Bundles
@@ -49,20 +108,20 @@ Bundles combine a preset with opinionated coverage settings (80% threshold on al
 
 ### Library bundle
 
-```javascript
-import { defineConfig } from "vitest/config";
+```typescript
 import { library } from "@theholocron/vitest-config/bundles/library";
+import { defineConfig } from "vitest/config";
 
-export default defineConfig({ test: library().test });
+export default defineConfig(library());
 ```
 
 ### React app bundle
 
-```javascript
-import { defineConfig } from "vitest/config";
+```typescript
 import { reactApp } from "@theholocron/vitest-config/bundles/react-app";
+import { defineConfig } from "vitest/config";
 
-export default defineConfig({ test: reactApp().test });
+export default defineConfig(reactApp());
 ```
 
 ## How We Test


### PR DESCRIPTION
## Summary

Catches READMEs up to recent shipped changes across three packages.

### `vitest-config`
- Documents `coverage` export and how to extend it
- Documents `setupMSWBrowser` / `setupMSWNode` helpers from `setup/msw`
- Shows recommended projects-based setup (unit + storybook as separate projects)
- Notes that `react` preset auto-includes `@testing-library/jest-dom`

### `vite-config`
- Adds `reactLibrary` preset section (ESM + CJS, `@vitejs/plugin-react`, `@` alias)

### `eslint-config`
- Fixes bundle import examples — they were showing default imports but exports are named (`{ reactApp }`, not `default`)
- Adds note that ESLint v10 is required and that `eslint-plugin-react` compat is handled internally