### PR TITLE
fix(lighthouse-config): document uploadTarget default in JSDoc

### DIFF
--- a/packages/lighthouse-config/index.ts
+++ b/packages/lighthouse-config/index.ts
@@ -33,6 +33,7 @@ export interface LighthouseConfigOptions {
 	url: string | string[];
 	startServerCommand?: string;
 	assertions?: LighthouseAssertion;
+	/** @default "temporary-public-storage" */
 	uploadTarget?: string;
 }
 


### PR DESCRIPTION
Triggers release to publish @theholocron/lighthouse-config@7.13.1 — the package was manually bootstrapped at 7.12.0 and needs a release cycle to reach lockstep.