### PR TITLE
chore: ⬆️ bump @theholocron/cli to ^3.10.0 and run holocron setup

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,7 +1,7 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Tool:    holocron sync-github
-# Changes: edit source in theholocron/holocron and push to alpha or main.
+# Tool:    holocron setup
+# Changes: run `holocron setup` to regenerate.
 name: Deploy Docs
 
 on: # yamllint disable-line rule:truthy
@@ -9,6 +9,7 @@ on: # yamllint disable-line rule:truthy
     branches: [main]
     paths:
       - docs/**
+      - packages/configs-docs/**
   workflow_dispatch:
 
 concurrency:
@@ -24,4 +25,6 @@ jobs:
   deploy-docs:
     name: Deploy Docs
     uses: theholocron/.github/.github/workflows/deploy-docs.yml@main
+    with:
+      name: configs
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Tool:    holocron sync-github
-# Changes: edit source in theholocron/holocron and push to alpha or main.
+# Tool:    holocron setup
+# Changes: run `holocron setup` to regenerate.
 name: Release
 
 on: # yamllint disable-line rule:truthy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ concurrency:
 permissions:
   contents: read
   id-token: write
+  statuses: write
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -93,10 +93,10 @@ docs/dist/
 
 # managed by holocron setup — skills
 /.agents/skills/
+/.claude/skills/turborepo
 /.claude/skills/git-safety
 /.claude/skills/pr-workflow
 /.claude/skills/commit-standards
 /.claude/skills/security-review
 /.claude/skills/holocron-skill-config
-/.claude/skills/turborepo
 # end managed by holocron setup — skills

--- a/codecov.yml
+++ b/codecov.yml
@@ -43,11 +43,6 @@ component_management:
       paths:
         - packages/commitlint-config/**
 
-    - component_id: lighthouse-config
-      name: "lighthouse-config"
-      paths:
-        - packages/lighthouse-config/**
-
     - component_id: configs-docs
       name: "configs-docs"
       paths:
@@ -62,6 +57,11 @@ component_management:
       name: "holocron-config"
       paths:
         - packages/holocron-config/**
+
+    - component_id: lighthouse-config
+      name: "lighthouse-config"
+      paths:
+        - packages/lighthouse-config/**
 
     - component_id: lint-staged-config
       name: "lint-staged-config"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,11 +20,11 @@ catalogs:
       version: 4.1.10
   holocron:
     '@theholocron/cli':
-      specifier: ^3.8.3
-      version: 3.8.3
+      specifier: ^3.10.0
+      version: 3.10.0
     '@theholocron/holocron-plugin-github':
-      specifier: ^3.8.3
-      version: 3.8.3
+      specifier: ^3.10.0
+      version: 3.10.0
 
 overrides:
   '@commitlint/config-conventional>conventional-changelog-conventionalcommits': '7'
@@ -58,7 +58,7 @@ importers:
         version: 12.0.9(semantic-release@25.0.8(typescript@5.9.3))
       '@theholocron/cli':
         specifier: catalog:holocron
-        version: 3.8.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)
+        version: 3.10.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)
       '@theholocron/commitlint-config':
         specifier: workspace:*
         version: link:packages/commitlint-config
@@ -70,7 +70,7 @@ importers:
         version: link:packages/holocron-config
       '@theholocron/holocron-plugin-github':
         specifier: catalog:holocron
-        version: 3.8.3(@theholocron/cli@3.8.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10))(@theholocron/github-client@1.6.0(vitest@4.1.10))
+        version: 3.10.0(@theholocron/cli@3.10.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10))(@theholocron/github-client@1.6.0(vitest@4.1.10))
       '@theholocron/lint-staged-config':
         specifier: workspace:*
         version: link:packages/lint-staged-config
@@ -270,7 +270,7 @@ importers:
     devDependencies:
       '@theholocron/cli':
         specifier: catalog:holocron
-        version: 3.8.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)
+        version: 3.10.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)
       '@theholocron/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -3227,8 +3227,8 @@ packages:
     peerDependencies:
       astro: '>=5.0.0'
 
-  '@theholocron/cli@3.8.3':
-    resolution: {integrity: sha512-W+bYpVHLQZJfnKB1Z6bEY7xiaCMWv4AirxRAznE0nibQ5B6LnOgLcl5+E+Yyn5T0D6l+5x+tXmPwhuwk0Yj1wQ==}
+  '@theholocron/cli@3.10.0':
+    resolution: {integrity: sha512-/C7g95njivFGAN1FCamwPeOZBnoQarDnnTqhVzsmKpjqnx6tetTjpUBfwltJFRAVmVfzN2Zv0HWeZRgNia1DXg==}
     hasBin: true
 
   '@theholocron/docs-theme@1.2.2':
@@ -3249,20 +3249,11 @@ packages:
     resolution: {integrity: sha512-h+nbOUTR+8YlObab7OMOs2MqpCrENrtHWcTySVBesoluJZoAQ4/uaqq2U7Z9WP5UT9+WN9J7R8/QrkGlxaPXtw==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/holocron-plugin-github@3.8.3':
-    resolution: {integrity: sha512-nZ7bybHR5dkTnt4VV9WytBY59O7tPlhSg4jRqu0WqvONBwPFXaDtJZB5NDaFaz1XXl2mQ/iHQWfyjHLlCu4CAA==}
+  '@theholocron/holocron-plugin-github@3.10.0':
+    resolution: {integrity: sha512-d+BBxLco8cO7X1nBFWDbiCUmJTxd3Aw9uzR731OFYfo/qHxLyPj+3+3KYoQQLt7/mgQHEG4JoTeKTsVF9FIa7g==}
     peerDependencies:
-      '@theholocron/cli': 3.8.3
+      '@theholocron/cli': 3.10.0
       '@theholocron/github-client': ^1.6.0
-
-  '@theholocron/http-client@1.5.5':
-    resolution: {integrity: sha512-IUWx0/aswJUSz8k0sNXPHAAAr5XZvt/Y8MVkXVoQFlpUQFnT45/3N0xlqnx/wz21DbtXDSxaloJ9A+6odVHosQ==}
-    engines: {node: '>=22.0.0'}
-    peerDependencies:
-      vitest: '>=4.0.0'
-    peerDependenciesMeta:
-      vitest:
-        optional: true
 
   '@theholocron/http-client@1.6.0':
     resolution: {integrity: sha512-dYWvKCcSVB1B71JsxWSxebVoyWxQiMouCGcoApeNK8WBmF03tSJVmLztdyGqwXEmq7codGCuW/hXj3qiHph1/g==}
@@ -11345,13 +11336,13 @@ snapshots:
     dependencies:
       astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.1.2)(jiti@2.6.1)(rollup@4.62.2)(tsx@4.23.1)(yaml@2.9.0)
 
-  '@theholocron/cli@3.8.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)':
+  '@theholocron/cli@3.10.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@26.1.2)
       '@napi-rs/keyring': 1.3.0
       '@sentry/node': 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
       '@theholocron/github-client': 1.6.0(vitest@4.1.10)
-      '@theholocron/http-client': 1.5.5(vitest@4.1.10)
+      '@theholocron/http-client': 1.6.0(vitest@4.1.10)
       chalk: 6.0.0
       ora: 9.4.1
       tsx: 4.23.1
@@ -11381,15 +11372,11 @@ snapshots:
     transitivePeerDependencies:
       - vitest
 
-  '@theholocron/holocron-plugin-github@3.8.3(@theholocron/cli@3.8.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10))(@theholocron/github-client@1.6.0(vitest@4.1.10))':
+  '@theholocron/holocron-plugin-github@3.10.0(@theholocron/cli@3.10.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10))(@theholocron/github-client@1.6.0(vitest@4.1.10))':
     dependencies:
-      '@theholocron/cli': 3.8.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)
+      '@theholocron/cli': 3.10.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@types/node@26.1.2)(vitest@4.1.10)
       '@theholocron/github-client': 1.6.0(vitest@4.1.10)
       libsodium-wrappers: 0.8.4
-
-  '@theholocron/http-client@1.5.5(vitest@4.1.10)':
-    optionalDependencies:
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
   '@theholocron/http-client@1.6.0(vitest@4.1.10)':
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,6 @@ catalog:
 # Holocron CLI and plugins — pinned in lockstep; bump together when running setup.
 catalogs:
   holocron:
-    '@theholocron/cli': ^3.8.3
+    '@theholocron/cli': ^3.10.0
     '@theholocron/holocron-config': ^7.6.1
-    '@theholocron/holocron-plugin-github': ^3.8.3
+    '@theholocron/holocron-plugin-github': ^3.10.0


### PR DESCRIPTION
Bumps `@theholocron/cli` and `@theholocron/holocron-plugin-github` to `^3.10.0` and runs `holocron setup` to apply updated workflow templates.

Key change: adds `statuses: write` to the `test.yml` caller permissions, fixing `startup_failure` caused by the `visual-and-composition` job in the shared reusable workflow. Root cause diagnosed in theholocron/holocron#315; fix landed in theholocron/holocron#316.