### PR TITLE
feat: add CJS build to lighthouse-config

### DIFF
--- a/packages/lighthouse-config/package.json
+++ b/packages/lighthouse-config/package.json
@@ -35,9 +35,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/lighthouse-config/tsdown.config.ts
+++ b/packages/lighthouse-config/tsdown.config.ts
@@ -2,8 +2,8 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
 	entry: ["index.ts"],
-	format: "esm",
-	fixedExtension: false,
+	format: ["esm", "cjs"],
+	fixedExtension: true,
 	dts: true,
 	clean: true,
 	deps: { dts: { neverBundle: /.*/ } },


### PR DESCRIPTION
## Summary

Adds a CommonJS output (`dist/index.cjs` + `dist/index.d.cts`) alongside the existing ESM build.

**Why:** LHCI (`@lhci/cli`) loads its config file via `require()`. In repos with `"type": "module"` in `package.json`, `.js` files are ESM and can't be `require()`d. The workaround is a `.cjs` config file, but that file previously couldn't `import` from `@theholocron/lighthouse-config` because the package was ESM-only. With this CJS output it can now use `require('@theholocron/lighthouse-config')`.

## Changes

- `tsdown.config.ts`: `format: ["esm", "cjs"]` + `fixedExtension: true` → outputs `.mjs`/`.cjs` instead of `.js`
- `package.json`: nested `import`/`require` conditions in exports map, each with their own `types` entry