### PR TITLE
fix: update react presets to @vitejs/plugin-react ^6 for Vite v8 Rolldown support

### DIFF
--- a/packages/vite-config/package.json
+++ b/packages/vite-config/package.json
@@ -69,14 +69,14 @@
   "peerDependencies": {
     "vite": "^6 || ^7 || ^8",
     "@codecov/vite-plugin": "^2",
-    "@vitejs/plugin-react-oxc": "^0.4",
+    "@vitejs/plugin-react": "^6",
     "vite-tsconfig-paths": "^5"
   },
   "peerDependenciesMeta": {
     "@codecov/vite-plugin": {
       "optional": true
     },
-    "@vitejs/plugin-react-oxc": {
+    "@vitejs/plugin-react": {
       "optional": true
     },
     "vite-tsconfig-paths": {

--- a/packages/vite-config/presets/react-app.ts
+++ b/packages/vite-config/presets/react-app.ts
@@ -8,7 +8,7 @@ import { getPackageName } from "./get-package-name.js";
  * Uploads bundle stats to Codecov when CODECOV_TOKEN is set.
  */
 export async function reactApp(overrides: UserConfig = {}): Promise<UserConfig> {
-	const { default: react } = await import("@vitejs/plugin-react-oxc");
+	const { default: react } = await import("@vitejs/plugin-react");
 
 	const plugins: NonNullable<UserConfig["plugins"]> = [react()];
 	try {

--- a/packages/vite-config/presets/react-library.ts
+++ b/packages/vite-config/presets/react-library.ts
@@ -22,7 +22,7 @@ export async function reactLibrary({
 } = {}): Promise<UserConfig> {
 	const resolvedName = name ?? getPackageName();
 
-	const { default: react } = await import("@vitejs/plugin-react-oxc");
+	const { default: react } = await import("@vitejs/plugin-react");
 
 	const plugins: NonNullable<UserConfig["plugins"]> = [react()];
 	try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,9 +546,9 @@ importers:
 
   packages/vite-config:
     dependencies:
-      '@vitejs/plugin-react-oxc':
-        specifier: ^0.4
-        version: 0.4.3(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitejs/plugin-react':
+        specifier: ^6
+        version: 6.0.5(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^5
         version: 5.1.4(typescript@5.9.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
@@ -2593,9 +2593,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-beta.47':
-    resolution: {integrity: sha512-8QagwMH3kNCuzD8EWL8R2YPW5e4OrHNSAHRFDdmFqEwEaD/KcNKjVoumo+gP2vW5eKB2UPbM6vTYiGZX0ixLnw==}
-
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
@@ -3489,11 +3486,18 @@ packages:
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
-  '@vitejs/plugin-react-oxc@0.4.3':
-    resolution: {integrity: sha512-eJv6hHOIOVXzA4b2lZwccu/7VNmk9372fGOqsx5tNxiJHLtFBokyCTQUhlgjjXxl7guLPauHp0TqGTVyn1HvQA==}
+  '@vitejs/plugin-react@6.0.5':
+    resolution: {integrity: sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^6.3.0 || ^7.0.0
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vitest/browser@4.1.10':
     resolution: {integrity: sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==}
@@ -10576,8 +10580,6 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.2.2':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-beta.47': {}
-
   '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/pluginutils@5.4.0(rollup@4.62.2)':
@@ -11628,9 +11630,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.3': {}
 
-  '@vitejs/plugin-react-oxc@0.4.3(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.5(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
-      '@rolldown/pluginutils': 1.0.0-beta.47
+      '@rolldown/pluginutils': 1.0.1
       vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/browser@4.1.10(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':


### PR DESCRIPTION
## Summary

Follows up on #343 which switched to `@vitejs/plugin-react-oxc` — that package is now deprecated because its OXC/Rolldown support was merged directly into `@vitejs/plugin-react` v6.

- Reverts both `react-app` and `react-library` presets back to `@vitejs/plugin-react`
- Updates peer dependency from `@vitejs/plugin-react-oxc ^0.4` → `@vitejs/plugin-react ^6`
- No API changes — `react()` call is identical