### PR TITLE
feat: ✨ add cli preset to tsdown-config

### DIFF
--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
 	},
 	workflows: [
 		...workflows,
+		{ name: "test", with: { "run-unit": true } },
 		{ name: "release", with: { "run-build": true } },
 		{
 			name: "deploy-docs",

--- a/packages/tsdown-config/README.md
+++ b/packages/tsdown-config/README.md
@@ -8,9 +8,11 @@ Shared [tsdown](https://tsdown.dev) configurations for `@theholocron` packages.
 pnpm add -D @theholocron/tsdown-config tsdown
 ```
 
-## Usage
+## Presets
 
-For a standard published ESM library (single entry, generates types, doesn't bundle `@theholocron/*` peers):
+### `library` — published ESM library
+
+Single entry point (`src/index.ts`), generates `.d.ts` type declarations, does not bundle `@theholocron/*` peers.
 
 ```ts
 // tsdown.config.ts
@@ -25,5 +27,25 @@ import { library } from "@theholocron/tsdown-config/presets/library";
 
 export default library({
 	entry: ["src/index.ts", "src/capabilities/index.ts"],
+});
+```
+
+### `cli` — CLI binary
+
+Single entry point (`src/cli.ts`), no type declarations (binaries don't need them), sourcemap enabled, injects `#!/usr/bin/env node` shebang so the output is directly executable.
+
+```ts
+// tsdown.config.ts
+export { default } from "@theholocron/tsdown-config/presets/cli";
+```
+
+To customise the entry point or other options, use the `cli()` factory:
+
+```ts
+// tsdown.config.ts
+import { cli } from "@theholocron/tsdown-config/presets/cli";
+
+export default cli({
+	entry: ["src/my-cli.ts"],
 });
 ```

--- a/packages/tsdown-config/index.test.ts
+++ b/packages/tsdown-config/index.test.ts
@@ -1,7 +1,36 @@
 import { describe, it, expect } from "vitest";
+import { cli } from "./presets/cli.js";
 import { library } from "./presets/library.js";
 
 describe("tsdown-config", () => {
+	describe("cli preset", () => {
+		it("returns a tsdown config object", () => {
+			const config = cli();
+			expect(typeof config).toBe("object");
+			expect(config).not.toBeNull();
+		});
+
+		it("targets ESM format", () => {
+			const config = cli();
+			expect(config.format).toContain("esm");
+		});
+
+		it("disables dts generation", () => {
+			const config = cli();
+			expect(config.dts).toBe(false);
+		});
+
+		it("adds Node.js shebang banner", () => {
+			const config = cli();
+			expect((config.banner as { js: string }).js).toBe("#!/usr/bin/env node");
+		});
+
+		it("accepts option overrides", () => {
+			const config = cli({ clean: false });
+			expect(config.clean).toBe(false);
+		});
+	});
+
 	describe("library preset", () => {
 		it("returns a tsdown config object", () => {
 			const config = library();

--- a/packages/tsdown-config/index.ts
+++ b/packages/tsdown-config/index.ts
@@ -1,1 +1,2 @@
+export { cli } from "./presets/cli.js";
 export { library } from "./presets/library.js";

--- a/packages/tsdown-config/package.json
+++ b/packages/tsdown-config/package.json
@@ -39,6 +39,11 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./presets/cli": {
+      "types": "./dist/presets/cli.d.ts",
+      "import": "./dist/presets/cli.js",
+      "default": "./dist/presets/cli.js"
+    },
     "./presets/library": {
       "types": "./dist/presets/library.d.ts",
       "import": "./dist/presets/library.js",

--- a/packages/tsdown-config/presets/cli.ts
+++ b/packages/tsdown-config/presets/cli.ts
@@ -1,0 +1,21 @@
+import { defineConfig, type UserConfig } from "tsdown";
+
+/**
+ * tsdown preset for a CLI binary.
+ * Builds src/cli.ts → dist/cli.mjs with a Node.js shebang banner.
+ * No type declarations — binaries don't need them.
+ */
+export function cli(options: UserConfig = {}) {
+	return defineConfig({
+		entry: ["src/cli.ts"],
+		format: "esm",
+		dts: false,
+		clean: true,
+		sourcemap: true,
+		banner: { js: "#!/usr/bin/env node" },
+		...options,
+	});
+}
+
+/** Ready-to-use config for CLIs that need no customisation. */
+export default cli();

--- a/packages/tsdown-config/presets/cli.ts
+++ b/packages/tsdown-config/presets/cli.ts
@@ -17,5 +17,4 @@ export function cli(options: UserConfig = {}) {
 	});
 }
 
-/** Ready-to-use config for CLIs that need no customisation. */
 export default cli();

--- a/packages/tsdown-config/tsdown.config.ts
+++ b/packages/tsdown-config/tsdown.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "tsdown";
 export default defineConfig({
-	entry: ["index.ts", "presets/library.ts"],
+	entry: ["index.ts", "presets/cli.ts", "presets/library.ts"],
 	format: "esm",
 	fixedExtension: false,
 	dts: true,

--- a/packages/tsdown-config/vitest.config.ts
+++ b/packages/tsdown-config/vitest.config.ts
@@ -1,3 +1,8 @@
-import { node } from "@theholocron/vitest-config";
+import { library } from "@theholocron/vitest-config/bundles/library";
 import { defineConfig } from "vitest/config";
-export default defineConfig(node());
+
+export default defineConfig(
+	library({
+		test: { passWithNoTests: false },
+	}) as never
+);


### PR DESCRIPTION
## Summary

- Adds `@theholocron/tsdown-config/presets/cli` — a tsdown preset for CLI binaries
- Builds `src/cli.ts` → `dist/cli.mjs`, ESM format, no dts, sourcemap, `#!/usr/bin/env node` shebang via banner
- Accepts option overrides the same way `library()` does
- Exports `./presets/cli` in package.json and re-exports `cli()` from the package root
- 5 new tests covering format, dts flag, shebang banner, and option overrides

## Usage

```ts
// tsdown.config.ts in a CLI repo
export { default } from "@theholocron/tsdown-config/presets/cli";
```

## Test plan

- [x] `pnpm --filter @theholocron/tsdown-config build` — produces `dist/presets/cli.js` + `.d.ts`
- [x] `pnpm --filter @theholocron/tsdown-config test` — 9/9 tests pass
- [ ] CI lint, typecheck, test all pass