### PR TITLE
feat(lighthouse-config): expose startServerReadyPattern and startServerReadyTimeout

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 codecov:
   require_ci_to_pass: true
+  max_report_age: off
 
 coverage:
   precision: 2

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
 	},
 	workflows: [
 		...workflows,
+		{ name: "test", with: { "run-unit": true } },
 		{ name: "release", with: { "run-build": true } },
 		{
 			name: "deploy-docs",

--- a/packages/lighthouse-config/index.test.ts
+++ b/packages/lighthouse-config/index.test.ts
@@ -63,5 +63,31 @@ describe("lighthouse-config", () => {
 			});
 			expect(config.ci.upload.target).toBe("lhci");
 		});
+
+		it("includes startServerReadyPattern when provided", () => {
+			const config = defineConfig({
+				url: "http://localhost:3000/",
+				startServerReadyPattern: "Accepting",
+			});
+			expect(config.ci.collect.startServerReadyPattern).toBe("Accepting");
+		});
+
+		it("omits startServerReadyPattern when not provided", () => {
+			const config = defineConfig({ url: "http://localhost:3000/" });
+			expect(config.ci.collect).not.toHaveProperty("startServerReadyPattern");
+		});
+
+		it("includes startServerReadyTimeout when provided", () => {
+			const config = defineConfig({
+				url: "http://localhost:3000/",
+				startServerReadyTimeout: 120000,
+			});
+			expect(config.ci.collect.startServerReadyTimeout).toBe(120000);
+		});
+
+		it("omits startServerReadyTimeout when not provided", () => {
+			const config = defineConfig({ url: "http://localhost:3000/" });
+			expect(config.ci.collect).not.toHaveProperty("startServerReadyTimeout");
+		});
 	});
 });

--- a/packages/lighthouse-config/index.test.ts
+++ b/packages/lighthouse-config/index.test.ts
@@ -77,6 +77,14 @@ describe("lighthouse-config", () => {
 			expect(config.ci.collect).not.toHaveProperty("startServerReadyPattern");
 		});
 
+		it("includes startServerReadyPattern when empty string", () => {
+			const config = defineConfig({
+				url: "http://localhost:3000/",
+				startServerReadyPattern: "",
+			});
+			expect(config.ci.collect.startServerReadyPattern).toBe("");
+		});
+
 		it("includes startServerReadyTimeout when provided", () => {
 			const config = defineConfig({
 				url: "http://localhost:3000/",
@@ -88,6 +96,14 @@ describe("lighthouse-config", () => {
 		it("omits startServerReadyTimeout when not provided", () => {
 			const config = defineConfig({ url: "http://localhost:3000/" });
 			expect(config.ci.collect).not.toHaveProperty("startServerReadyTimeout");
+		});
+
+		it("includes startServerReadyTimeout when 0", () => {
+			const config = defineConfig({
+				url: "http://localhost:3000/",
+				startServerReadyTimeout: 0,
+			});
+			expect(config.ci.collect.startServerReadyTimeout).toBe(0);
 		});
 	});
 });

--- a/packages/lighthouse-config/index.ts
+++ b/packages/lighthouse-config/index.ts
@@ -32,6 +32,10 @@ export const defaultAssertions: LighthouseAssertion = {
 export interface LighthouseConfigOptions {
 	url: string | string[];
 	startServerCommand?: string;
+	/** Pattern lhci waits for in server stdout before running audits. Defaults to lhci's built-in /(listen|ready)/i. */
+	startServerReadyPattern?: string;
+	/** Milliseconds to wait for startServerReadyPattern before timing out. */
+	startServerReadyTimeout?: number;
 	assertions?: LighthouseAssertion;
 	/** @default "temporary-public-storage" */
 	uploadTarget?: string;
@@ -40,6 +44,8 @@ export interface LighthouseConfigOptions {
 export function defineConfig({
 	url,
 	startServerCommand,
+	startServerReadyPattern,
+	startServerReadyTimeout,
 	assertions = defaultAssertions,
 	uploadTarget = "temporary-public-storage",
 }: LighthouseConfigOptions) {
@@ -48,6 +54,8 @@ export function defineConfig({
 			collect: {
 				url: Array.isArray(url) ? url : [url],
 				...(startServerCommand ? { startServerCommand } : {}),
+				...(startServerReadyPattern ? { startServerReadyPattern } : {}),
+				...(startServerReadyTimeout ? { startServerReadyTimeout } : {}),
 			},
 			assert: { assertions },
 			upload: { target: uploadTarget },

--- a/packages/lighthouse-config/index.ts
+++ b/packages/lighthouse-config/index.ts
@@ -54,8 +54,8 @@ export function defineConfig({
 			collect: {
 				url: Array.isArray(url) ? url : [url],
 				...(startServerCommand ? { startServerCommand } : {}),
-				...(startServerReadyPattern ? { startServerReadyPattern } : {}),
-				...(startServerReadyTimeout ? { startServerReadyTimeout } : {}),
+				...(startServerReadyPattern !== undefined ? { startServerReadyPattern } : {}),
+				...(startServerReadyTimeout !== undefined ? { startServerReadyTimeout } : {}),
 			},
 			assert: { assertions },
 			upload: { target: uploadTarget },

--- a/packages/lighthouse-config/vitest.config.ts
+++ b/packages/lighthouse-config/vitest.config.ts
@@ -1,4 +1,13 @@
+import { coverage, node } from "@theholocron/vitest-config";
 import { defineConfig } from "vitest/config";
-import { node } from "@theholocron/vitest-config";
 
-export default defineConfig(node());
+export default defineConfig({
+	...node(),
+	test: {
+		...node().test,
+		coverage: {
+			...coverage,
+			include: ["index.ts"],
+		},
+	},
+});

--- a/packages/tsdown-config/README.md
+++ b/packages/tsdown-config/README.md
@@ -8,9 +8,11 @@ Shared [tsdown](https://tsdown.dev) configurations for `@theholocron` packages.
 pnpm add -D @theholocron/tsdown-config tsdown
 ```
 
-## Usage
+## Presets
 
-For a standard published ESM library (single entry, generates types, doesn't bundle `@theholocron/*` peers):
+### `library` — published ESM library
+
+Single entry point (`src/index.ts`), generates `.d.ts` type declarations, does not bundle `@theholocron/*` peers.
 
 ```ts
 // tsdown.config.ts
@@ -25,5 +27,25 @@ import { library } from "@theholocron/tsdown-config/presets/library";
 
 export default library({
 	entry: ["src/index.ts", "src/capabilities/index.ts"],
+});
+```
+
+### `cli` — CLI binary
+
+Single entry point (`src/cli.ts`), no type declarations (binaries don't need them), sourcemap enabled, injects `#!/usr/bin/env node` shebang so the output is directly executable.
+
+```ts
+// tsdown.config.ts
+export { default } from "@theholocron/tsdown-config/presets/cli";
+```
+
+To customise the entry point or other options, use the `cli()` factory:
+
+```ts
+// tsdown.config.ts
+import { cli } from "@theholocron/tsdown-config/presets/cli";
+
+export default cli({
+	entry: ["src/my-cli.ts"],
 });
 ```

--- a/packages/tsdown-config/index.test.ts
+++ b/packages/tsdown-config/index.test.ts
@@ -1,7 +1,36 @@
 import { describe, it, expect } from "vitest";
+import { cli } from "./presets/cli.js";
 import { library } from "./presets/library.js";
 
 describe("tsdown-config", () => {
+	describe("cli preset", () => {
+		it("returns a tsdown config object", () => {
+			const config = cli();
+			expect(typeof config).toBe("object");
+			expect(config).not.toBeNull();
+		});
+
+		it("targets ESM format", () => {
+			const config = cli();
+			expect(config.format).toContain("esm");
+		});
+
+		it("disables dts generation", () => {
+			const config = cli();
+			expect(config.dts).toBe(false);
+		});
+
+		it("adds Node.js shebang banner", () => {
+			const config = cli();
+			expect((config.banner as { js: string }).js).toBe("#!/usr/bin/env node");
+		});
+
+		it("accepts option overrides", () => {
+			const config = cli({ clean: false });
+			expect(config.clean).toBe(false);
+		});
+	});
+
 	describe("library preset", () => {
 		it("returns a tsdown config object", () => {
 			const config = library();

--- a/packages/tsdown-config/index.ts
+++ b/packages/tsdown-config/index.ts
@@ -1,1 +1,2 @@
+export { cli } from "./presets/cli.js";
 export { library } from "./presets/library.js";

--- a/packages/tsdown-config/package.json
+++ b/packages/tsdown-config/package.json
@@ -39,6 +39,11 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./presets/cli": {
+      "types": "./dist/presets/cli.d.ts",
+      "import": "./dist/presets/cli.js",
+      "default": "./dist/presets/cli.js"
+    },
     "./presets/library": {
       "types": "./dist/presets/library.d.ts",
       "import": "./dist/presets/library.js",

--- a/packages/tsdown-config/presets/cli.ts
+++ b/packages/tsdown-config/presets/cli.ts
@@ -1,0 +1,21 @@
+import { defineConfig, type UserConfig } from "tsdown";
+
+/**
+ * tsdown preset for a CLI binary.
+ * Builds src/cli.ts → dist/cli.mjs with a Node.js shebang banner.
+ * No type declarations — binaries don't need them.
+ */
+export function cli(options: UserConfig = {}) {
+	return defineConfig({
+		entry: ["src/cli.ts"],
+		format: "esm",
+		dts: false,
+		clean: true,
+		sourcemap: true,
+		banner: { js: "#!/usr/bin/env node" },
+		...options,
+	});
+}
+
+/** Ready-to-use config for CLIs that need no customisation. */
+export default cli();

--- a/packages/tsdown-config/presets/cli.ts
+++ b/packages/tsdown-config/presets/cli.ts
@@ -17,5 +17,4 @@ export function cli(options: UserConfig = {}) {
 	});
 }
 
-/** Ready-to-use config for CLIs that need no customisation. */
 export default cli();

--- a/packages/tsdown-config/tsdown.config.ts
+++ b/packages/tsdown-config/tsdown.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "tsdown";
 export default defineConfig({
-	entry: ["index.ts", "presets/library.ts"],
+	entry: ["index.ts", "presets/cli.ts", "presets/library.ts"],
 	format: "esm",
 	fixedExtension: false,
 	dts: true,

--- a/packages/tsdown-config/vitest.config.ts
+++ b/packages/tsdown-config/vitest.config.ts
@@ -1,3 +1,8 @@
-import { node } from "@theholocron/vitest-config";
+import { library } from "@theholocron/vitest-config/bundles/library";
 import { defineConfig } from "vitest/config";
-export default defineConfig(node());
+
+export default defineConfig(
+	library({
+		test: { passWithNoTests: false },
+	}) as never
+);


### PR DESCRIPTION
## Summary

- Add `startServerReadyPattern` and `startServerReadyTimeout` as optional parameters to `defineConfig`
- Both pass through directly to lhci's `collect` config when provided

## Why

`serve` outputs `"Accepting connections"` which doesn't match lhci's default `/(listen|ready)/i`, causing lhci to fire Lighthouse before the server is ready. Without this, repos have to mutate the returned config object directly (brittle). Closes #349.

## Test plan

- [ ] `nextjs-template` lighthouse audit passes after picking up the new release

🤖 Generated with [Claude Code](https://claude.com/claude-code)