### PR TITLE
feat(tsconfig): add react preset with DOM lib and bundler resolution

### DIFF
--- a/packages/configs-docs/content/tsconfig.md
+++ b/packages/configs-docs/content/tsconfig.md
@@ -32,3 +32,13 @@ For Next.js apps. Extends the Next.js recommended TypeScript configuration.
   "extends": "@theholocron/tsconfig/nextjs"
 }
 ```
+
+### `react`
+
+For browser-targeted React component libraries and Vite apps. Includes DOM lib, `ESNext` module with `bundler` resolution, and the `react-jsx` transform.
+
+```json
+{
+  "extends": "@theholocron/tsconfig/react"
+}
+```

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -29,3 +29,13 @@ Targets the current Node LTS feature set. All theholocron projects use this:
   "extends": "@theholocron/tsconfig/node-lts"
 }
 ```
+
+### React
+
+Targets browser environments for React component libraries and apps. Sets `DOM` lib, `ESNext` module with `bundler` resolution, and `react-jsx` transform — no manual overrides needed for Vite-based projects:
+
+```json
+{
+  "extends": "@theholocron/tsconfig/react"
+}
+```

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -18,11 +18,13 @@
   ],
   "exports": {
     "./nextjs": "./nextjs/tsconfig.json",
-    "./node-lts": "./node-lts/tsconfig.json"
+    "./node-lts": "./node-lts/tsconfig.json",
+    "./react": "./react/tsconfig.json"
   },
   "files": [
     "nextjs/tsconfig.json",
-    "node-lts/tsconfig.json"
+    "node-lts/tsconfig.json",
+    "react/tsconfig.json"
   ],
   "peerDependencies": {
     "typescript": "^5"

--- a/packages/tsconfig/react/tsconfig.json
+++ b/packages/tsconfig/react/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "React (ESM, bundler)",
+
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2020",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `react` tsconfig preset for browser-targeted React component library packages that extend `@theholocron/tsconfig/react`.

- `lib: [ESNext, DOM, DOM.Iterable]` — enables browser globals (`document`, `window`, etc.)
- `moduleResolution: bundler` — works with Vite without requiring explicit file extensions
- `module: ESNext` — ESM output
- `jsx: react-jsx` — modern React JSX transform (no need to import React)
- Inherits strict settings from the base

The existing `node-lts` preset targets Node.js and lacks DOM — previously, React packages were forced to manually override `lib`, `module`, and `moduleResolution`. This preset makes those overrides unnecessary.

## Consumers

- `monorepo-react-template/packages/package-b` (immediate use)
- `react-template`, `monorepo-nextjs-template/packages/ui` (can migrate)

## Test plan

- [ ] A package extending `@theholocron/tsconfig/react` typechecks browser code without errors