### PR TITLE
feat(tsconfig): add Astro preset

### DIFF
--- a/packages/tsconfig/astro/tsconfig.json
+++ b/packages/tsconfig/astro/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Astro (ESM, bundler)",
+
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "allowImportingTsExtensions": true,
+    "allowJs": true,
+    "noEmit": true,
+    "strictNullChecks": true,
+    "skipLibCheck": true
+  }
+}

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -17,11 +17,13 @@
     "theholocron"
   ],
   "exports": {
+    "./astro": "./astro/tsconfig.json",
     "./nextjs": "./nextjs/tsconfig.json",
     "./node-lts": "./node-lts/tsconfig.json",
     "./react": "./react/tsconfig.json"
   },
   "files": [
+    "astro/tsconfig.json",
     "nextjs/tsconfig.json",
     "node-lts/tsconfig.json",
     "react/tsconfig.json"


### PR DESCRIPTION
## Summary

Adds `@theholocron/tsconfig/astro` — a TypeScript preset for Astro projects.

Inlines the options from `astro/tsconfigs/strict` rather than extending it, so `astro` is not required as a peer dependency of `@theholocron/tsconfig`. Adds `skipLibCheck: true` which is necessary when Starlight (and other Astro integrations) ship `.ts` source files with virtual module imports that TypeScript can't resolve outside of a running Astro context.

## Usage

```json
{
  "extends": "@theholocron/tsconfig/astro",
  "include": [".astro/types.d.ts", "astro.config.ts", "docs/src/**/*"],
  "exclude": ["docs/dist", "packages"]
}
```

## Test plan

- [ ] `pnpm --filter @theholocron/tsconfig typecheck` (no typecheck script — JSON only, no build needed)
- [ ] Consuming repo (`theholocron/themes`) adopts the preset and tsc passes after `astro sync`