### PR TITLE
chore(docs): move astro tsconfig into docs/, add package.json shim

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@theholocron/configs-site",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "astro build --root ..",
+    "dev": "astro dev --root ..",
+    "preview": "astro preview --root .."
+  }
+}

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@theholocron/tsconfig/astro",
+  "include": [".astro/types.d.ts", "../astro.config.ts", "src/**/*"],
+  "exclude": ["dist"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,0 @@
-{
-  "extends": "@theholocron/tsconfig/astro",
-  "include": [".astro/types.d.ts", "astro.config.ts", "docs/src/**/*"],
-  "exclude": ["docs/dist", "packages"]
-}


### PR DESCRIPTION
## Summary

- Move `docs/tsconfig.json` from repo root into `docs/` — Volar walks upward from each source file so it is picked up for all content under `docs/src/`, consistent with all other repos
- Add `docs/package.json` as a script shim (no deps): `build/dev/preview` delegate via `astro ... --root ..` so the deploy workflow's `pnpm -C docs build` resolves correctly without `docs/` being a workspace member