### PR TITLE
feat(eslint-config): add eslint-package-json to lint package.json files

### DIFF
--- a/packages/eslint-config/bundles/library.ts
+++ b/packages/eslint-config/bundles/library.ts
@@ -1,5 +1,6 @@
 import { base } from "../configs/base.js";
 import { node } from "../configs/node.js";
+import { packageJson } from "../configs/package-json.js";
 import { typescript } from "../configs/typescript.js";
 
 export function library() {
@@ -7,6 +8,7 @@ export function library() {
 		...base(),
 		...node(),
 		...typescript(),
+		...packageJson(),
 		{
 			name: "@theholocron/library",
 			rules: {

--- a/packages/eslint-config/bundles/next-app.ts
+++ b/packages/eslint-config/bundles/next-app.ts
@@ -2,11 +2,12 @@ import type { Linter } from "eslint";
 import { base } from "../configs/base.js";
 import { cypress } from "../configs/cypress.js";
 import { next } from "../configs/next.js";
+import { packageJson } from "../configs/package-json.js";
 import { react } from "../configs/react.js";
 import { typescript } from "../configs/typescript.js";
 import { storybook } from "../configs/storybook.js";
 import { vitest } from "../configs/vitest.js";
 
 export function nextApp(): Linter.FlatConfig[] {
-	return [...base(), ...typescript(), ...react(), ...next(), ...vitest(), ...storybook(), ...cypress()];
+	return [...base(), ...typescript(), ...react(), ...next(), ...vitest(), ...storybook(), ...cypress(), ...packageJson()];
 }

--- a/packages/eslint-config/bundles/next-app.ts
+++ b/packages/eslint-config/bundles/next-app.ts
@@ -9,5 +9,14 @@ import { storybook } from "../configs/storybook.js";
 import { vitest } from "../configs/vitest.js";
 
 export function nextApp(): Linter.FlatConfig[] {
-	return [...base(), ...typescript(), ...react(), ...next(), ...vitest(), ...storybook(), ...cypress(), ...packageJson()];
+	return [
+		...base(),
+		...typescript(),
+		...react(),
+		...next(),
+		...vitest(),
+		...storybook(),
+		...cypress(),
+		...packageJson(),
+	];
 }

--- a/packages/eslint-config/bundles/node-app.ts
+++ b/packages/eslint-config/bundles/node-app.ts
@@ -1,8 +1,9 @@
 import { base } from "../configs/base.js";
 import { node } from "../configs/node.js";
+import { packageJson } from "../configs/package-json.js";
 import { typescript } from "../configs/typescript.js";
 import { vitest } from "../configs/vitest.js";
 
 export function nodeApp() {
-	return [...base(), ...node(), ...typescript(), ...vitest()];
+	return [...base(), ...node(), ...typescript(), ...vitest(), ...packageJson()];
 }

--- a/packages/eslint-config/bundles/react-app.ts
+++ b/packages/eslint-config/bundles/react-app.ts
@@ -1,9 +1,10 @@
 import { base } from "../configs/base.js";
+import { packageJson } from "../configs/package-json.js";
 import { react } from "../configs/react.js";
 import { storybook } from "../configs/storybook.js";
 import { typescript } from "../configs/typescript.js";
 import { vitest } from "../configs/vitest.js";
 
 export function reactApp() {
-	return [...base(), ...typescript(), ...react(), ...storybook(), ...vitest()];
+	return [...base(), ...typescript(), ...react(), ...storybook(), ...vitest(), ...packageJson()];
 }

--- a/packages/eslint-config/configs/package-json.ts
+++ b/packages/eslint-config/configs/package-json.ts
@@ -1,0 +1,20 @@
+import type { Linter } from "eslint";
+import eslintPackageJson from "eslint-package-json";
+
+export function packageJson(): Linter.Config[] {
+	return [
+		{
+			name: "@theholocron/package-json",
+			...eslintPackageJson.configs.recommended,
+			rules: {
+				...eslintPackageJson.configs.recommended.rules,
+				// pnpm catalog: specifiers (e.g. "catalog:configs") are not standard
+				// semver ranges — this rule would flag every theholocron catalog entry.
+				"package-json/dependency-version-range": "off",
+				// workspace:* is intentional in peerDependencies for monorepo-internal
+				// packages; turning off avoids false positives on pnpm workspace refs.
+				"package-json/no-wildcard-dependencies": "off",
+			},
+		},
+	];
+}

--- a/packages/eslint-config/index.test.ts
+++ b/packages/eslint-config/index.test.ts
@@ -1,6 +1,7 @@
 import { Linter } from "eslint";
 import { describe, it, expect } from "vitest";
 import { base } from "./configs/base.js";
+import { packageJson } from "./configs/package-json.js";
 import { typescript } from "./configs/typescript.js";
 import { node } from "./configs/node.js";
 import { react } from "./configs/react.js";
@@ -34,6 +35,32 @@ describe("eslint-config — individual configs", () => {
 	it("react() config runs without throwing on ESLint v10 context API", () => {
 		const linter = new Linter({ configType: "flat" });
 		expect(() => linter.verify("const x = 1;", react() as Parameters<Linter["verify"]>[1])).not.toThrow();
+	});
+});
+
+describe("eslint-config — package-json config", () => {
+	it("packageJson() returns a non-empty flat config array", () => {
+		const config = packageJson();
+		expect(Array.isArray(config)).toBe(true);
+		expect(config.length).toBeGreaterThan(0);
+	});
+
+	it("packageJson() targets package.json files", () => {
+		const config = packageJson();
+		const files = config.flatMap((c) => ("files" in c ? (c.files as string[]) : []));
+		expect(files.some((f) => f.includes("package.json"))).toBe(true);
+	});
+
+	it("packageJson() disables dependency-version-range", () => {
+		const config = packageJson();
+		const rules = config.flatMap((c) => ("rules" in c ? Object.entries(c.rules ?? {}) : []));
+		expect(rules.some(([k, v]) => k === "package-json/dependency-version-range" && v === "off")).toBe(true);
+	});
+
+	it("packageJson() disables no-wildcard-dependencies", () => {
+		const config = packageJson();
+		const rules = config.flatMap((c) => ("rules" in c ? Object.entries(c.rules ?? {}) : []));
+		expect(rules.some(([k, v]) => k === "package-json/no-wildcard-dependencies" && v === "off")).toBe(true);
 	});
 });
 

--- a/packages/eslint-config/index.ts
+++ b/packages/eslint-config/index.ts
@@ -1,2 +1,3 @@
 export { base } from "./configs/base.js";
+export { packageJson } from "./configs/package-json.js";
 export { typescript } from "./configs/typescript.js";

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -28,7 +28,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@eslint/compat": "^2.1.0"
+    "@eslint/compat": "^2.1.0",
+    "eslint-package-json": "^0.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",
@@ -72,6 +73,11 @@
       "types": "./dist/configs/node.d.ts",
       "import": "./dist/configs/node.js",
       "default": "./dist/configs/node.js"
+    },
+    "./package-json": {
+      "types": "./dist/configs/package-json.d.ts",
+      "import": "./dist/configs/package-json.js",
+      "default": "./dist/configs/package-json.js"
     },
     "./vitest": {
       "types": "./dist/configs/vitest.d.ts",
@@ -121,8 +127,8 @@
     "eslint-plugin-cypress": "^6",
     "eslint-plugin-n": "^18",
     "eslint-plugin-react": "^7",
-    "eslint-plugin-storybook": "^10",
     "eslint-plugin-simple-import-sort": "^14",
+    "eslint-plugin-storybook": "^10",
     "globals": "^17",
     "typescript-eslint": "^8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       eslint:
         specifier: ^10
         version: 10.8.1(jiti@2.6.1)
+      eslint-package-json:
+        specifier: ^0.3.0
+        version: 0.3.0(eslint@10.8.1(jiti@2.6.1))
       eslint-plugin-cypress:
         specifier: ^6
         version: 6.4.2(@typescript-eslint/parser@8.66.0(eslint@10.8.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.8.1(jiti@2.6.1))
@@ -257,7 +260,7 @@ importers:
         version: 8.66.0(eslint@10.8.1(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))
 
   packages/holocron-config:
     devDependencies:
@@ -575,7 +578,7 @@ importers:
     dependencies:
       '@storybook/addon-vitest':
         specifier: ^9
-        version: 9.1.20(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0)))(vitest@4.1.10)
+        version: 9.1.20(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0)))(vitest@4.1.10)
       '@testing-library/jest-dom':
         specifier: ^6
         version: 6.9.1
@@ -587,10 +590,10 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/browser':
         specifier: ^4
-        version: 4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))(vitest@4.1.10)
+        version: 4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/browser-playwright':
         specifier: ^4
-        version: 4.1.10(playwright@1.61.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))(vitest@4.1.10)
+        version: 4.1.10(playwright@1.61.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))(vitest@4.1.10)
       jsdom:
         specifier: ^26
         version: 26.1.0
@@ -612,7 +615,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))
 
 packages:
 
@@ -1544,6 +1547,10 @@ packages:
       eslint:
         optional: true
 
+  '@eslint/json@2.0.1':
+    resolution: {integrity: sha512-Thz2j92ceUF3Bq/0TuWb3MWn3Z+Cwc8k5ptF0fakl2D4Mp8mSx07Xr1aQM4R5NoihzarWUdxfOmQ8DesGy4jOg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@eslint/object-schema@3.0.5':
     resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -1593,6 +1600,10 @@ packages:
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
+
+  '@humanwhocodes/momoa@3.3.10':
+    resolution: {integrity: sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==}
+    engines: {node: '>=18'}
 
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
@@ -4638,6 +4649,12 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
+  eslint-package-json@0.3.0:
+    resolution: {integrity: sha512-znnM6ynvEBTTpQ/iq9hqY4OUcJ/O++wMxKpVqPu+Re/8wCsGvU0DUR/65xNI9u98ajCnn0wHkR+tAmrW2C2D3A==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      eslint: '>=10.4'
+
   eslint-plugin-cypress@6.4.2:
     resolution: {integrity: sha512-OIGJP5y6/cyMxBtMASP/iBM7Pv4ZHccE9uI8MhtAZDrdNDYDwHgKa/3Khrr+FGRr9hSIfNYstGRhSmbcLURWYA==}
     peerDependencies:
@@ -5288,6 +5305,10 @@ packages:
 
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
+
+  hosted-git-info@10.1.1:
+    resolution: {integrity: sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
@@ -6526,6 +6547,10 @@ packages:
     resolution: {integrity: sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg==}
     engines: {node: '>=20'}
 
+  npm-package-arg@14.0.0:
+    resolution: {integrity: sha512-69XQh3k+dtGa1p+7RaR57IuG3rCko96xr/nUfN4yDYBXbTYICiWcOpsFKLN2GtGE9cyIljE+f1exnaYt9MvM+Q==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
@@ -7000,6 +7025,10 @@ packages:
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
+
+  proc-log@7.0.0:
+    resolution: {integrity: sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   process-ancestry@0.1.0:
     resolution: {integrity: sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg==}
@@ -7544,6 +7573,9 @@ packages:
 
   spdx-expression-parse@3.0.1:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-expression-parse@4.0.0:
+    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
 
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
@@ -8235,6 +8267,14 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  validate-npm-package-name@7.0.2:
+    resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  validate-npm-package-name@8.0.0:
+    resolution: {integrity: sha512-SCv6OOV6Xj2/3cXy3dGmADluJTNcL3o7hZAglNPTe+WYuEuvxgJzxPrSDLZhF+CwyQOubqgecjMmTJGMVLWjYQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   verkit@0.3.1:
     resolution: {integrity: sha512-w2Eo8LSIIoW7qxNBzT7/17k+bh8plXo7G3dHjEIDqPlnluhzaxr9JX8F28VSYEtDvc1/a3WBDih6xNUZseebXg==}
@@ -9494,6 +9534,13 @@ snapshots:
     optionalDependencies:
       eslint: 10.8.1(jiti@2.6.1)
 
+  '@eslint/json@2.0.1':
+    dependencies:
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanwhocodes/momoa': 3.3.10
+      natural-compare: 1.4.0
+
   '@eslint/object-schema@3.0.5': {}
 
   '@eslint/plugin-kit@0.7.2':
@@ -9555,6 +9602,8 @@ snapshots:
   '@humanfs/types@0.15.0': {}
 
   '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/momoa@3.3.10': {}
 
   '@humanwhocodes/retry@0.4.3': {}
 
@@ -10896,6 +10945,22 @@ snapshots:
       storybook: 9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))
       ts-dedent: 2.3.0
 
+  '@storybook/addon-vitest@9.1.20(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0)))(vitest@4.1.10)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 1.6.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      prompts: 2.4.2
+      storybook: 9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))
+      ts-dedent: 2.3.0
+    optionalDependencies:
+      '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.61.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/runner': 4.1.10
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@storybook/addon-vitest@9.1.20(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@9.2.0-alpha.3(@testing-library/dom@10.4.1)(prettier@3.9.5)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0)))(vitest@4.1.10)':
     dependencies:
       '@storybook/global': 5.0.0
@@ -11449,7 +11514,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/browser-playwright@4.1.10(playwright@1.61.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
@@ -11463,6 +11527,7 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
   '@vitest/browser@4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
@@ -11480,7 +11545,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/browser@4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.4)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
@@ -11498,6 +11562,7 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
   '@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)':
     dependencies:
@@ -12880,6 +12945,17 @@ snapshots:
       eslint: 10.8.1(jiti@2.6.1)
       semver: 7.8.5
 
+  eslint-package-json@0.3.0(eslint@10.8.1(jiti@2.6.1)):
+    dependencies:
+      '@eslint/json': 2.0.1
+      detect-indent: 7.0.2
+      eslint: 10.8.1(jiti@2.6.1)
+      hosted-git-info: 10.1.1
+      npm-package-arg: 14.0.0
+      semver: 7.8.5
+      spdx-expression-parse: 4.0.0
+      validate-npm-package-name: 7.0.2
+
   eslint-plugin-cypress@6.4.2(@typescript-eslint/parser@8.66.0(eslint@10.8.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.8.1(jiti@2.6.1)):
     dependencies:
       eslint: 10.8.1(jiti@2.6.1)
@@ -13778,6 +13854,10 @@ snapshots:
   hookified@1.15.1: {}
 
   hookified@2.2.0: {}
+
+  hosted-git-info@10.1.1:
+    dependencies:
+      lru-cache: 11.5.2
 
   hosted-git-info@7.0.2:
     dependencies:
@@ -15477,6 +15557,13 @@ snapshots:
 
   normalize-url@9.0.1: {}
 
+  npm-package-arg@14.0.0:
+    dependencies:
+      hosted-git-info: 10.1.1
+      proc-log: 7.0.0
+      semver: 7.8.5
+      validate-npm-package-name: 8.0.0
+
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
@@ -15903,6 +15990,8 @@ snapshots:
       parse-ms: 4.0.0
 
   prismjs@1.30.0: {}
+
+  proc-log@7.0.0: {}
 
   process-ancestry@0.1.0: {}
 
@@ -16742,6 +16831,11 @@ snapshots:
       spdx-exceptions: 2.5.0
       spdx-license-ids: 3.0.23
 
+  spdx-expression-parse@4.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
   spdx-license-ids@3.0.23: {}
 
   split2@1.0.0:
@@ -17460,6 +17554,10 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  validate-npm-package-name@7.0.2: {}
+
+  validate-npm-package-name@8.0.0: {}
 
   verkit@0.3.1: {}
 


### PR DESCRIPTION
## Summary

Closes #365.

Adds a `packageJson()` config backed by [`eslint-package-json`](https://github.com/sindresorhus/eslint-package-json) v0.3.0. The recommended ruleset catches real mistakes across all repos:

- `no-workspace-protocol-in-published-package` — guards against `workspace:` refs shipping
- `no-orphan-types` — `@types/*` without a corresponding runtime dep
- `require-types-in-exports` — types must be first and module-compatible in exports
- `sort-dependencies` / `sort-properties` — consistent ordering (autofix)
- `valid-fields` — invalid values for known fields (autofix)
- `require-engines` — `engines.node` required

Two rules disabled for theholocron's pnpm patterns:
- `dependency-version-range: off` — `catalog:` specifiers are not standard semver and would flag every catalog entry
- `no-wildcard-dependencies: off` — `workspace:*` is intentional for monorepo `peerDependencies`

`packageJson()` is included in all four bundles (`library`, `nodeApp`, `nextApp`, `reactApp`) — every consuming repo gets it automatically.

## Test plan

- [ ] `pnpm --filter @theholocron/eslint-config typecheck` — clean
- [ ] `pnpm --filter @theholocron/eslint-config test` — 11 tests pass (4 new for packageJson())