### PR TITLE
fix(devmoji): remove --lint from prepare-commit-msg hook

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -17,4 +17,4 @@ git interpret-trailers --if-exists doNothing --trailer \
 	"Signed-off-by: $NAME <$EMAIL>" \
 	--in-place "$1"
 
-npx devmoji -e --lint
+npx devmoji -e


### PR DESCRIPTION
## Summary

Removes `--lint` from the `prepare-commit-msg` hook.

`prepare-commit-msg` fires **before** the editor opens on interactive `git commit` — the message is still empty at that point, so `--lint` rejects it. Commitlint in `commit-msg` handles validation after the message is written.

Fixes: `husky - prepare-commit-msg script failed (code 1)` when using `git commit` without `-m`.