### PR TITLE
docs: add lighthouse-config page and sidebar entry

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
 					{ label: "Devmoji", slug: "devmoji-config" },
 					{ label: "ESLint", slug: "eslint-config" },
 					{ label: "Holocron", slug: "holocron-config" },
+					{ label: "Lighthouse", slug: "lighthouse-config" },
 					{ label: "Lint Staged", slug: "lint-staged-config" },
 					{ label: "Prettier", slug: "prettier-config" },
 					{ label: "Semantic Release", slug: "semantic-release-config" },

--- a/docs/src/content/docs/astro-config.md
+++ b/docs/src/content/docs/astro-config.md
@@ -1,38 +1,60 @@
 ---
 title: Astro Config
-description: Astro configuration factory for theholocron docs sites.
+description: Astro + Starlight configuration factory for theholocron per-repo docs sites.
 ---
 
-`@theholocron/astro-config` provides a `defineConfig` factory that generates a standard Astro + Starlight configuration for per-repo docs sites, deriving the base URL, title, social links, and sidebar from the repo's docs config package.
+`@theholocron/astro-config` provides a `defineConfig` factory that wires up a standard Astro + Starlight configuration for per-repo docs sites, including base path, title, GitHub social link, sidebar, and the shared `docsTheme` plugin.
 
 ## Install
 
 ```bash
-pnpm add -D @theholocron/astro-config
+pnpm add -D @theholocron/astro-config @astrojs/starlight @theholocron/docs-theme
 ```
 
 ## Usage
 
 ```ts
 // astro.config.ts
+import starlight from "@astrojs/starlight";
 import { defineConfig } from "@theholocron/astro-config";
-import clientsConfig from "@theholocron/clients-docs";
+import { docsTheme } from "@theholocron/docs-theme";
 
 export default defineConfig({
-  docs: clientsConfig,
-  importMetaUrl: import.meta.url,
+  docs: {
+    name: "My Package",
+    github: "my-repo",
+    sidebar: [
+      { label: "Overview", slug: "" },
+      {
+        label: "Packages",
+        items: [{ label: "Something", slug: "something" }],
+      },
+    ],
+  },
+  starlight,
+  docsTheme,
+  srcDir: "./docs/src",
+  outDir: "./docs/dist",
+  publicDir: "./docs/public",
 });
 ```
 
-### Custom sidebar label
+## Options
 
-```ts
-import { defineConfig } from "@theholocron/astro-config";
-import holocronConfig from "@theholocron/holocron-docs";
+| Option        | Required | Description                                                                             |
+| ------------- | -------- | --------------------------------------------------------------------------------------- |
+| `docs`        | Yes      | Site metadata — `name`, `github` slug, and `sidebar` config                            |
+| `starlight`   | Yes      | The `starlight` integration import from `@astrojs/starlight`                            |
+| `docsTheme`   | Yes      | The `docsTheme` export from `@theholocron/docs-theme`                                   |
+| `srcDir`      | No       | Astro `srcDir` — use when `astro.config.ts` lives at the repo root, e.g. `./docs/src`  |
+| `outDir`      | No       | Astro `outDir`, e.g. `./docs/dist`                                                      |
+| `publicDir`   | No       | Astro `publicDir`, e.g. `./docs/public`                                                 |
+| `base`        | No       | URL base path. Defaults to `/${docs.github}` for GitHub Pages subpath deployment        |
 
-export default defineConfig({
-  docs: holocronConfig,
-  importMetaUrl: import.meta.url,
-  sidebarLabel: "Reference",
-});
-```
+## Exports
+
+| Export           | Description                            |
+| ---------------- | -------------------------------------- |
+| `defineConfig`   | Factory that returns an Astro config   |
+| `DocsConfig`     | Type for the `docs` field              |
+| `DocsConfigInput`| Full options type for `defineConfig`   |

--- a/docs/src/content/docs/lighthouse-config.md
+++ b/docs/src/content/docs/lighthouse-config.md
@@ -1,0 +1,45 @@
+---
+title: Lighthouse Config
+description: Shared Lighthouse CI assertion config for theholocron projects.
+---
+
+`@theholocron/lighthouse-config` provides a shared [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci) assertion configuration used across theholocron front-end projects.
+
+## Install
+
+```bash
+pnpm add -D @theholocron/lighthouse-config
+```
+
+## Usage
+
+In your `lighthouserc.cjs`:
+
+```js
+const { defaultAssertions, defineConfig } = require("@theholocron/lighthouse-config");
+
+module.exports = defineConfig({
+  url: "http://localhost:4321",
+  startServerCommand: "pnpm preview",
+  assertions: {
+    ...defaultAssertions,
+    // override individual assertions as needed
+    "largest-contentful-paint": ["error", { minScore: 0.8 }],
+  },
+});
+```
+
+## Exports
+
+| Export               | Description                                                              |
+| -------------------- | ------------------------------------------------------------------------ |
+| `defineConfig`       | Factory that produces a typed `lighthouserc` config object               |
+| `defaultAssertions`  | Pre-set assertion thresholds covering core Web Vitals and common audits  |
+| `LighthouseAssertion`| Type for the `assertions` map                                            |
+| `LighthouseConfigOptions` | Options type for `defineConfig`                                     |
+
+## Default assertions
+
+The bundled `defaultAssertions` warn on the following audits falling below `0.9` (or exceeding `0` bytes where applicable):
+
+`bf-cache`, `errors-in-console`, `font-display`, `label`, `largest-contentful-paint`, `lcp-lazy-loaded`, `non-composited-animations`, `prioritize-lcp-image`, `unused-javascript`, `uses-long-cache-ttl`


### PR DESCRIPTION
Adds a missing `lighthouse-config.md` doc page covering install, usage, exports, and default assertions. Adds the sidebar entry in alphabetical position between Holocron and Lint Staged.