### PR TITLE
docs: add astro-config and lighthouse-config to docs index table

### DIFF
--- a/docs/src/content/docs/astro-config.md
+++ b/docs/src/content/docs/astro-config.md
@@ -41,20 +41,20 @@ export default defineConfig({
 
 ## Options
 
-| Option        | Required | Description                                                                             |
-| ------------- | -------- | --------------------------------------------------------------------------------------- |
-| `docs`        | Yes      | Site metadata — `name`, `github` slug, and `sidebar` config                            |
-| `starlight`   | Yes      | The `starlight` integration import from `@astrojs/starlight`                            |
-| `docsTheme`   | Yes      | The `docsTheme` export from `@theholocron/docs-theme`                                   |
-| `srcDir`      | No       | Astro `srcDir` — use when `astro.config.ts` lives at the repo root, e.g. `./docs/src`  |
-| `outDir`      | No       | Astro `outDir`, e.g. `./docs/dist`                                                      |
-| `publicDir`   | No       | Astro `publicDir`, e.g. `./docs/public`                                                 |
-| `base`        | No       | URL base path. Defaults to `/${docs.github}` for GitHub Pages subpath deployment        |
+| Option      | Required | Description                                                                           |
+| ----------- | -------- | ------------------------------------------------------------------------------------- |
+| `docs`      | Yes      | Site metadata — `name`, `github` slug, and `sidebar` config                           |
+| `starlight` | Yes      | The `starlight` integration import from `@astrojs/starlight`                          |
+| `docsTheme` | Yes      | The `docsTheme` export from `@theholocron/docs-theme`                                 |
+| `srcDir`    | No       | Astro `srcDir` — use when `astro.config.ts` lives at the repo root, e.g. `./docs/src` |
+| `outDir`    | No       | Astro `outDir`, e.g. `./docs/dist`                                                    |
+| `publicDir` | No       | Astro `publicDir`, e.g. `./docs/public`                                               |
+| `base`      | No       | URL base path. Defaults to `/${docs.github}` for GitHub Pages subpath deployment      |
 
 ## Exports
 
-| Export           | Description                            |
-| ---------------- | -------------------------------------- |
-| `defineConfig`   | Factory that returns an Astro config   |
-| `DocsConfig`     | Type for the `docs` field              |
-| `DocsConfigInput`| Full options type for `defineConfig`   |
+| Export            | Description                          |
+| ----------------- | ------------------------------------ |
+| `defineConfig`    | Factory that returns an Astro config |
+| `DocsConfig`      | Type for the `docs` field            |
+| `DocsConfigInput` | Full options type for `defineConfig` |

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -11,11 +11,13 @@ sidebar:
 
 | Package                                                             | Description                                        |
 | ------------------------------------------------------------------- | -------------------------------------------------- |
+| [`@theholocron/astro-config`](./astro-config)                       | Astro + Starlight docs site configuration          |
 | [`@theholocron/browserslist-config`](./browserslist-config)         | Browserslist target browser list                   |
 | [`@theholocron/commitlint-config`](./commitlint-config)             | CommitLint rules for Conventional Commits          |
 | [`@theholocron/devmoji-config`](./devmoji-config)                   | Devmoji emoji mappings for conventional commits    |
 | [`@theholocron/eslint-config`](./eslint-config)                     | ESLint configs and bundles                         |
 | [`@theholocron/holocron-config`](./holocron-config)                 | Shareable Holocron CLI presets                     |
+| [`@theholocron/lighthouse-config`](./lighthouse-config)             | Lighthouse CI performance and accessibility audits |
 | [`@theholocron/lint-staged-config`](./lint-staged-config)           | Lint-staged hooks configuration                    |
 | [`@theholocron/prettier-config`](./prettier-config)                 | Prettier formatting rules                          |
 | [`@theholocron/semantic-release-config`](./semantic-release-config) | semantic-release factory with Conventional Commits |

--- a/docs/src/content/docs/lighthouse-config.md
+++ b/docs/src/content/docs/lighthouse-config.md
@@ -31,12 +31,12 @@ module.exports = defineConfig({
 
 ## Exports
 
-| Export               | Description                                                              |
-| -------------------- | ------------------------------------------------------------------------ |
-| `defineConfig`       | Factory that produces a typed `lighthouserc` config object               |
-| `defaultAssertions`  | Pre-set assertion thresholds covering core Web Vitals and common audits  |
-| `LighthouseAssertion`| Type for the `assertions` map                                            |
-| `LighthouseConfigOptions` | Options type for `defineConfig`                                     |
+| Export                    | Description                                                             |
+| ------------------------- | ----------------------------------------------------------------------- |
+| `defineConfig`            | Factory that produces a typed `lighthouserc` config object              |
+| `defaultAssertions`       | Pre-set assertion thresholds covering core Web Vitals and common audits |
+| `LighthouseAssertion`     | Type for the `assertions` map                                           |
+| `LighthouseConfigOptions` | Options type for `defineConfig`                                         |
 
 ## Default assertions
 


### PR DESCRIPTION
Both packages exist, have doc pages, and appear in the sidebar — but were missing from the `index.md` overview table. Adds them in alphabetical order.