### PR TITLE
fix: ✨ add n/no-unpublished-import off to library bundle

### DIFF
--- a/packages/eslint-config/bundles/library.ts
+++ b/packages/eslint-config/bundles/library.ts
@@ -17,6 +17,10 @@ export function library() {
 				// (e.g. tsdown banner) rather than written in source. The hashbang rule
 				// produces false positives in both cases for the library use-case.
 				"n/hashbang": "off",
+				// tsdown compiles src/ → dist/ and package.json#files lists dist/ only.
+				// Every relative src/ import is therefore flagged as unpublished — a
+				// universal false positive for the TypeScript src→dist build model.
+				"n/no-unpublished-import": "off",
 			},
 		},
 	];


### PR DESCRIPTION
## Summary

Adds `"n/no-unpublished-import": "off"` to the `library` bundle.

This rule is a universal false positive for the tsdown `src → dist` build model: when `package.json#files` only lists `dist/`, every relative `src/` import is flagged as unpublished. Five root configs and 14 per-package configs across the org have been adding this override locally with identical comments — this centralises it.

Closes #376.

## Repos to clean up after merge + release

The per-repo override can be removed from:
- `theholocron/holocron` (root config)
- `theholocron/utils` (root config)
- `theholocron/clients` (root + 14 package configs)
- `theholocron/node-template`
- `theholocron/monorepo-template`

## Note on #377 (react/react-in-jsx-scope)

The `react` config already includes `react.configs.flat["jsx-runtime"]` which sets `react/react-in-jsx-scope: 0`. The per-repo manual overrides in `nextjs-template` and `react-template` are redundant — they can be removed without any change to the shared config. Closing #377 as won't-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)