### PR TITLE
feat(eslint-config): add /jsdoc preset and ~ Vite alias in astro-config

### DIFF
--- a/packages/astro-config/index.ts
+++ b/packages/astro-config/index.ts
@@ -28,7 +28,8 @@ export function defineConfig({ docs, starlight, docsTheme, srcDir, outDir, publi
 		...(publicDir && { publicDir }),
 		vite: {
 			resolve: {
-				alias: { "~": process.cwd() },
+				// @/ maps to the docs src dir so MDX pages avoid deep relative imports
+				alias: { "@": new URL(srcDir ?? "src", `file://${process.cwd()}/`).pathname },
 			},
 		},
 		integrations: [

--- a/packages/astro-config/index.ts
+++ b/packages/astro-config/index.ts
@@ -26,6 +26,11 @@ export function defineConfig({ docs, starlight, docsTheme, srcDir, outDir, publi
 		...(srcDir && { srcDir }),
 		...(outDir && { outDir }),
 		...(publicDir && { publicDir }),
+		vite: {
+			resolve: {
+				alias: { "~": process.cwd() },
+			},
+		},
 		integrations: [
 			starlight({
 				title: docs.name,

--- a/packages/eslint-config/configs/jsdoc.ts
+++ b/packages/eslint-config/configs/jsdoc.ts
@@ -1,0 +1,35 @@
+import jsdoc from "eslint-plugin-jsdoc";
+import type { Linter } from "eslint";
+
+export function jsdocConfig(): Linter.Config[] {
+	return [
+		{
+			...(jsdoc.configs["flat/recommended-typescript"] as Linter.Config),
+			name: "@theholocron/jsdoc/recommended",
+		},
+		{
+			name: "@theholocron/jsdoc",
+			rules: {
+				"jsdoc/require-jsdoc": [
+					"error",
+					{
+						publicOnly: true,
+						require: {
+							FunctionDeclaration: true,
+							MethodDefinition: false,
+							ClassDeclaration: true,
+							ArrowFunctionExpression: false,
+							FunctionExpression: false,
+						},
+					},
+				],
+				"jsdoc/require-description": "error",
+				"jsdoc/require-param-description": "error",
+				"jsdoc/require-returns-description": "error",
+				"jsdoc/tag-lines": ["error", "never"],
+			},
+		},
+	];
+}
+
+export { jsdocConfig as jsdoc };

--- a/packages/eslint-config/configs/package-json.ts
+++ b/packages/eslint-config/configs/package-json.ts
@@ -14,6 +14,10 @@ export function packageJson(): Linter.Config[] {
 				// workspace:* is intentional in peerDependencies for monorepo-internal
 				// packages; turning off avoids false positives on pnpm workspace refs.
 				"package-json/no-wildcard-dependencies": "off",
+				// @eslint/json 2.x provides a JSON sourceCode object without
+				// getAllComments(), causing this core rule to crash when linting
+				// package.json files. JSON files have no comments to check anyway.
+				"no-irregular-whitespace": "off",
 			},
 		},
 	];

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -54,6 +54,11 @@
       "import": "./dist/configs/base.js",
       "default": "./dist/configs/base.js"
     },
+    "./jsdoc": {
+      "types": "./dist/configs/jsdoc.d.ts",
+      "import": "./dist/configs/jsdoc.js",
+      "default": "./dist/configs/jsdoc.js"
+    },
     "./typescript": {
       "types": "./dist/configs/typescript.d.ts",
       "import": "./dist/configs/typescript.js",
@@ -125,6 +130,7 @@
     "@vitest/eslint-plugin": "^1",
     "eslint": "^10",
     "eslint-plugin-cypress": "^6",
+    "eslint-plugin-jsdoc": "^50.0.0",
     "eslint-plugin-n": "^18",
     "eslint-plugin-react": "^7",
     "eslint-plugin-simple-import-sort": "^14",
@@ -134,6 +140,9 @@
   },
   "peerDependenciesMeta": {
     "@next/eslint-plugin-next": {
+      "optional": true
+    },
+    "eslint-plugin-jsdoc": {
       "optional": true
     },
     "@vitest/eslint-plugin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       eslint-plugin-cypress:
         specifier: ^6
         version: 6.4.2(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))
+      eslint-plugin-jsdoc:
+        specifier: ^50.0.0
+        version: 50.8.0(eslint@10.8.1(jiti@2.7.0))
       eslint-plugin-n:
         specifier: ^18
         version: 18.2.2(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
@@ -1243,6 +1246,10 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@es-joy/jsdoccomment@0.50.2':
+    resolution: {integrity: sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -4038,6 +4045,10 @@ packages:
   archy@1.0.0:
     resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
 
+  are-docs-informative@0.0.2:
+    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
+    engines: {node: '>=14'}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -4479,6 +4490,10 @@ packages:
 
   commander@3.0.2:
     resolution: {integrity: sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==}
+
+  comment-parser@1.4.1:
+    resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
+    engines: {node: '>= 12.0.0'}
 
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
@@ -5028,6 +5043,12 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
+  eslint-plugin-jsdoc@50.8.0:
+    resolution: {integrity: sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
+
   eslint-plugin-n@18.2.2:
     resolution: {integrity: sha512-gOO0lIqwEjZ750kv9/SptCWArUoAZXJoBr0vYWTO2dCBxctHUXlBIigiC8xuxxr/NKqgIT6Ehz1xRcilj8a5cA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -5079,6 +5100,10 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-visitor-keys@5.0.1:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -5092,6 +5117,10 @@ packages:
     peerDependenciesMeta:
       jiti:
         optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
@@ -6288,6 +6317,10 @@ packages:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
+  jsdoc-type-pratt-parser@4.1.0:
+    resolution: {integrity: sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==}
+    engines: {node: '>=12.0.0'}
+
   jsdom@26.1.0:
     resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
     engines: {node: '>=18'}
@@ -7254,6 +7287,9 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parse-imports-exports@0.2.4:
+    resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
+
   parse-json@4.0.0:
     resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
     engines: {node: '>=4'}
@@ -7276,6 +7312,9 @@ packages:
   parse-passwd@1.0.0:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
     engines: {node: '>=0.10.0'}
+
+  parse-statements@1.0.11:
+    resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
@@ -9880,6 +9919,14 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@es-joy/jsdoccomment@0.50.2':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@typescript-eslint/types': 8.67.0
+      comment-parser: 1.4.1
+      esquery: 1.7.0
+      jsdoc-type-pratt-parser: 4.1.0
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -12539,6 +12586,8 @@ snapshots:
 
   archy@1.0.0: {}
 
+  are-docs-informative@0.0.2: {}
+
   arg@5.0.2: {}
 
   argparse@1.0.10:
@@ -13080,6 +13129,8 @@ snapshots:
   commander@14.0.3: {}
 
   commander@3.0.2: {}
+
+  comment-parser@1.4.1: {}
 
   common-ancestor-path@2.0.0: {}
 
@@ -13705,6 +13756,22 @@ snapshots:
       eslint: 10.8.1(jiti@2.7.0)
       eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0))
 
+  eslint-plugin-jsdoc@50.8.0(eslint@10.8.1(jiti@2.7.0)):
+    dependencies:
+      '@es-joy/jsdoccomment': 0.50.2
+      are-docs-informative: 0.0.2
+      comment-parser: 1.4.1
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint: 10.8.1(jiti@2.7.0)
+      espree: 10.4.0
+      esquery: 1.7.0
+      parse-imports-exports: 0.2.4
+      semver: 7.8.5
+      spdx-expression-parse: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-n@18.2.2(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.1(jiti@2.7.0))
@@ -13778,6 +13845,8 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
+  eslint-visitor-keys@4.2.1: {}
+
   eslint-visitor-keys@5.0.1: {}
 
   eslint@10.8.1(jiti@2.7.0):
@@ -13816,6 +13885,12 @@ snapshots:
       jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
+      eslint-visitor-keys: 4.2.1
 
   espree@11.2.0:
     dependencies:
@@ -15419,6 +15494,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdoc-type-pratt-parser@4.1.0: {}
+
   jsdom@26.1.0:
     dependencies:
       cssstyle: 4.6.0
@@ -16687,6 +16764,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse-imports-exports@0.2.4:
+    dependencies:
+      parse-statements: 1.0.11
+
   parse-json@4.0.0:
     dependencies:
       error-ex: 1.3.4
@@ -16717,6 +16798,8 @@ snapshots:
   parse-ms@4.0.0: {}
 
   parse-passwd@1.0.0: {}
+
+  parse-statements@1.0.11: {}
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     dependencies:


### PR DESCRIPTION
Ticket 2.3 from \`.notes/2-mdx-migration.md\`.

## Changes

**\`@theholocron/eslint-config\` — new \`/jsdoc\` subpath**
- \`configs/jsdoc.ts\` — extends \`flat/recommended-typescript\` from \`eslint-plugin-jsdoc\`, enforces JSDoc on exported \`FunctionDeclaration\` and \`ClassDeclaration\`, requires descriptions on params and returns
- Adds \`eslint-plugin-jsdoc ^50\` as an optional peer dependency
- Adds \`./jsdoc\` to \`exports\`

**\`@theholocron/astro-config\` — \`~\` Vite alias**
- \`defineConfig\` now sets \`vite.resolve.alias["~"] = process.cwd()\` so \`~/...\` imports resolve to the repo root in every consuming docs site's Astro build

## Must merge before
Note 2 tickets 2.4–2.7 (per-repo MDX migration in clients, holocron, utils, skills).