### PR TITLE
fix: 🐛 disable no-irregular-whitespace for package.json files

### DIFF
--- a/packages/astro-config/index.ts
+++ b/packages/astro-config/index.ts
@@ -26,13 +26,6 @@ export function defineConfig({ docs, starlight, docsTheme, srcDir, outDir, publi
 		...(srcDir && { srcDir }),
 		...(outDir && { outDir }),
 		...(publicDir && { publicDir }),
-		vite: {
-			resolve: {
-				// @/ maps to the docs src directory so MDX pages can import
-				// without deep relative paths (e.g. @/links.config.ts)
-				alias: { "@": new URL(srcDir ?? "src", `file://${process.cwd()}/`).pathname },
-			},
-		},
 		integrations: [
 			starlight({
 				title: docs.name,

--- a/packages/astro-config/index.ts
+++ b/packages/astro-config/index.ts
@@ -26,6 +26,13 @@ export function defineConfig({ docs, starlight, docsTheme, srcDir, outDir, publi
 		...(srcDir && { srcDir }),
 		...(outDir && { outDir }),
 		...(publicDir && { publicDir }),
+		vite: {
+			resolve: {
+				// @/ maps to the docs src directory so MDX pages can import
+				// without deep relative paths (e.g. @/links.config.ts)
+				alias: { "@": new URL(srcDir ?? "src", `file://${process.cwd()}/`).pathname },
+			},
+		},
 		integrations: [
 			starlight({
 				title: docs.name,

--- a/packages/eslint-config/configs/package-json.ts
+++ b/packages/eslint-config/configs/package-json.ts
@@ -14,6 +14,10 @@ export function packageJson(): Linter.Config[] {
 				// workspace:* is intentional in peerDependencies for monorepo-internal
 				// packages; turning off avoids false positives on pnpm workspace refs.
 				"package-json/no-wildcard-dependencies": "off",
+				// @eslint/json 2.x provides a JSON sourceCode object without
+				// getAllComments(), causing this core rule to crash when linting
+				// package.json files. JSON files have no comments to check anyway.
+				"no-irregular-whitespace": "off",
 			},
 		},
 	];


### PR DESCRIPTION
## Problem

`@eslint/json@2.x` (released this week) provides a JSON `sourceCode` object that doesn't implement `getAllComments()`. When `no-irregular-whitespace` — a core ESLint rule that calls `getAllComments` — is applied to package.json files via `eslint-package-json`, ESLint crashes with:

```
TypeError: Error while loading rule 'no-irregular-whitespace': sourceCode.getAllComments is not a function
```

This broke any repo running ESLint against package.json files after `@eslint/json@2.0.1` was published.

## Fix

Disable `no-irregular-whitespace` in the `package-json` config. JSON files have no comments, so the rule is a no-op there anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
