### PR TITLE
fix: pin conventional-changelog-conventionalcommits to 9.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "overrides": {
       "@commitlint/config-conventional>conventional-changelog-conventionalcommits": "7",
       "yuku-parser": "0.6.3",
-      "uuid": "^11.1.1"
+      "uuid": "^11.1.1",
+      "conventional-changelog-conventionalcommits": "9.3.1"
     },
     "onlyBuiltDependencies": [
       "esbuild"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,7 @@ overrides:
   '@commitlint/config-conventional>conventional-changelog-conventionalcommits': '7'
   yuku-parser: 0.6.3
   uuid: ^11.1.1
+  conventional-changelog-conventionalcommits: 9.3.1
 
 importers:
 
@@ -112,8 +113,8 @@ importers:
         specifier: ^7.2.2
         version: 7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.4)(yaml@2.9.0)
       conventional-changelog-conventionalcommits:
-        specifier: ^10.3.0
-        version: 10.3.0
+        specifier: 9.3.1
+        version: 9.3.1
       eslint:
         specifier: ^10.8.1
         version: 10.8.1(jiti@2.7.0)
@@ -422,8 +423,8 @@ importers:
         specifier: ^14
         version: 14.1.1(semantic-release@25.0.7(typescript@5.9.3))
       conventional-changelog-conventionalcommits:
-        specifier: ^10
-        version: 10.2.1
+        specifier: 9.3.1
+        version: 9.3.1
       semantic-release:
         specifier: ^24 || ^25
         version: 25.0.7(typescript@5.9.3)
@@ -1264,10 +1265,6 @@ packages:
         optional: true
       conventional-commits-parser:
         optional: true
-
-  '@conventional-changelog/template@1.2.1':
-    resolution: {integrity: sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==}
-    engines: {node: '>=22'}
 
   '@conventional-changelog/template@1.3.0':
     resolution: {integrity: sha512-GsCw/qu92GI0EX6s7fxUi/SG1lmFjG9XZivxxEDZXqztuQKCn5o5wKdz4v005zci0Md7EZzgAwmQLoIEDZoaow==}
@@ -4721,17 +4718,13 @@ packages:
     resolution: {integrity: sha512-0MWQLVUT1oVCsUGs9aAWteBVxPlLwJTn5VbQH7B0B3fDizZgrJ9QGnKl/2mp1+5P7153GCBCjO/v1aKJ6eysCg==}
     engines: {node: '>=22'}
 
-  conventional-changelog-conventionalcommits@10.2.1:
-    resolution: {integrity: sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==}
-    engines: {node: '>=22'}
-
-  conventional-changelog-conventionalcommits@10.3.0:
-    resolution: {integrity: sha512-qag0zFD867Qq1DK0jAWicyWlEMS1FFC/BLVLISaoeI7Y6Em6aWchk7BCkhOTsecRpMsV6qX41XmlNnghiiTmSw==}
-    engines: {node: '>=22'}
-
   conventional-changelog-conventionalcommits@7.0.2:
     resolution: {integrity: sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==}
     engines: {node: '>=16'}
+
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
 
   conventional-changelog-writer@8.4.0:
     resolution: {integrity: sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==}
@@ -10340,8 +10333,6 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 7.1.2
 
-  '@conventional-changelog/template@1.2.1': {}
-
   '@conventional-changelog/template@1.3.0': {}
 
   '@conventional-changelog/template@1.4.0': {}
@@ -13796,15 +13787,11 @@ snapshots:
     dependencies:
       '@conventional-changelog/template': 1.3.0
 
-  conventional-changelog-conventionalcommits@10.2.1:
-    dependencies:
-      '@conventional-changelog/template': 1.2.1
-
-  conventional-changelog-conventionalcommits@10.3.0:
-    dependencies:
-      '@conventional-changelog/template': 1.3.0
-
   conventional-changelog-conventionalcommits@7.0.2:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@9.3.1:
     dependencies:
       compare-func: 2.0.0
 


### PR DESCRIPTION
The `pnpm.overrides` block already had the commitlint transitive pin but not a direct override. `semantic-release@25` bundles `conventional-changelog-writer@8`, which is incompatible with preset v10 (requires writer v9+). Pins to `9.3.1` to match.