### PR TITLE
fix(eslint-config): disable no-workspace-protocol-in-published-package

### DIFF
--- a/packages/eslint-config/configs/package-json.ts
+++ b/packages/eslint-config/configs/package-json.ts
@@ -12,8 +12,10 @@ export function packageJson(): Linter.Config[] {
 				// semver ranges — this rule would flag every theholocron catalog entry.
 				"package-json/dependency-version-range": "off",
 				// workspace:* is intentional in peerDependencies for monorepo-internal
-				// packages; turning off avoids false positives on pnpm workspace refs.
+				// packages; pnpm rewrites these to real versions on publish.
+				// Both rules are false positives for pnpm workspaces.
 				"package-json/no-wildcard-dependencies": "off",
+				"package-json/no-workspace-protocol-in-published-package": "off",
 				// @eslint/json 2.x provides a JSON sourceCode object without
 				// getAllComments(), causing this core rule to crash when linting
 				// package.json files. JSON files have no comments to check anyway.


### PR DESCRIPTION
The rule flags `workspace:*` in `peerDependencies`, but pnpm automatically rewrites it to the actual published version during `pnpm publish`. This is a false positive for pnpm workspaces — same category as `no-wildcard-dependencies` which is already disabled for the same reason.