### PR TITLE
fix: 🐛 disable no-nested-exports in packageJson() config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Chores
 
-* **deps:** Bump @theholocron/holocron-plugin-github from 3.24.4 to 3.29.12 in the all-dependencies group ([#391](https://github.com/theholocron/configs/issues/391)) ([f7c26b3](https://github.com/theholocron/configs/commit/f7c26b38db2bbe3b26b6c3b59735a10b2ada03c0))
+- **deps:** Bump @theholocron/holocron-plugin-github from 3.24.4 to 3.29.12 in the all-dependencies group ([#391](https://github.com/theholocron/configs/issues/391)) ([f7c26b3](https://github.com/theholocron/configs/commit/f7c26b38db2bbe3b26b6c3b59735a10b2ada03c0))
 
 ## [7.25.2](https://github.com/theholocron/configs/compare/v7.25.1...v7.25.2) (2026-08-26)
 

--- a/packages/eslint-config/configs/package-json.ts
+++ b/packages/eslint-config/configs/package-json.ts
@@ -26,6 +26,12 @@ export function packageJson(): Linter.Config[] {
 				// is safe — these rules are meaningless for package.json files.
 				"n/no-unsupported-features/node-builtins": "off",
 				"n/no-extraneous-require": "off",
+				// In a pnpm workspace, packages/* dirs are each the root of an
+				// independently published package, not nested package.json files.
+				// The rule has no workspace awareness and fires on every workspace
+				// package that declares exports. The rule docs explicitly recommend
+				// disabling for such manifests.
+				"package-json/no-nested-exports": "off",
 				// Canonical order matching sort-package-json's sortOrder so that the
 				// pre-commit hook and this rule agree and never conflict.
 				"package-json/sort-properties": [


### PR DESCRIPTION
## Summary

Disable `package-json/no-nested-exports` in the shared `packageJson()` config.

In a pnpm workspace, `packages/*` dirs are each the root of an independently published package — not nested `package.json` files in the npm sense. The rule has no workspace awareness and fires on every workspace package that declares an `exports` field. This is a false positive in every monorepo using this shared config.

The rule's own docs state: *"In a monorepo or any repository containing independent nested packages, lint each package with its own working directory or disable this rule for those manifests."*

Removing ad-hoc local overrides from `utils`, `clients`, `monorepo-react-template`, and `monorepo-nextjs-template` will follow once this releases.

## Test plan

- [ ] CI passes
- [ ] `pnpm exec eslint packages/*/package.json` in a monorepo no longer reports `no-nested-exports`
