### PR TITLE
ci: 👷 add deploy preview and cleanup jobs to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Tool:    holocron sync-github
-# Changes: edit source in theholocron/holocron and push to alpha or main.
+# Tool:    holocron sync
+# Changes: run `holocron sync` to regenerate.
 name: Deploy
 
 on: # yamllint disable-line rule:truthy
@@ -12,21 +12,51 @@ on: # yamllint disable-line rule:truthy
       - astro.config.ts
       - pnpm-workspace.yaml
       - pnpm-lock.yaml
+
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - docs/**
+      - astro.config.ts
+      - pnpm-workspace.yaml
+      - pnpm-lock.yaml
+
   workflow_dispatch:
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: ${{ github.event_name == 'pull_request' && format('deploy-preview-{0}', github.event.pull_request.number) || 'pages' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
 
 permissions:
   contents: read
+  deployments: write
   pages: write
   id-token: write
+  pull-requests: write
 
 jobs:
   deploy:
     name: Deploy
+    if: ${{ github.event_name != 'pull_request' }}
     uses: theholocron/.github/.github/workflows/deploy.yml@main
     with:
       type: docs
+    secrets: inherit
+
+  preview:
+    name: Deploy Preview
+    if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
+    uses: theholocron/.github/.github/workflows/deploy-preview.yml@main
+    with:
+      type: docs
+      cloudflare-project: theholocron-preview
+    secrets: inherit
+
+  cleanup:
+    name: Clean up Preview
+    if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+    uses: theholocron/.github/.github/workflows/cleanup-preview.yml@main
+    with:
+      cloudflare-project: theholocron-preview
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ### Bug Fixes
 
-* **astro-config:** 🐛 bump @astrojs/react to ^5.0.0 — v4 uses @vitejs/plugin-react peered to vite@6, incompatible with Astro 7 / Vite 8 Rolldown ([#395](https://github.com/theholocron/configs/issues/395)) ([7697638](https://github.com/theholocron/configs/commit/7697638abd6d7299a5d522824a4fbee7f33d7ea8))
+- **astro-config:** 🐛 bump @astrojs/react to ^5.0.0 — v4 uses @vitejs/plugin-react peered to vite@6, incompatible with Astro 7 / Vite 8 Rolldown ([#395](https://github.com/theholocron/configs/issues/395)) ([7697638](https://github.com/theholocron/configs/commit/7697638abd6d7299a5d522824a4fbee7f33d7ea8))
 
 ## [7.25.4](https://github.com/theholocron/configs/compare/v7.25.3...v7.25.4) (2026-08-26)
 
 ### Bug Fixes
 
-* 🐛 disable no-nested-exports in packageJson() config ([#394](https://github.com/theholocron/configs/issues/394)) ([72a2121](https://github.com/theholocron/configs/commit/72a2121b0a718547814676f0aff77bd94ac0e7d7))
+- 🐛 disable no-nested-exports in packageJson() config ([#394](https://github.com/theholocron/configs/issues/394)) ([72a2121](https://github.com/theholocron/configs/commit/72a2121b0a718547814676f0aff77bd94ac0e7d7))
 
 ## [7.25.3](https://github.com/theholocron/configs/compare/v7.25.2...v7.25.3) (2026-08-26)
 

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -6,6 +6,9 @@ const { repo, workflows, providers } = node();
 export default defineConfig({
 	description: "Shared configuration files.",
 	homepage: "https://docs.theholocron.dev/configs/",
+	org: "theholocron",
+	domain: "theholocron.dev",
+	docs: { build: "workflow", https: true },
 	repo: {
 		teams: [{ slug: "gatekeepers", permission: "maintain" }],
 		topics: [
@@ -55,12 +58,13 @@ export default defineConfig({
 		{ name: "test", with: { "run-unit": true } },
 		{ name: "release", with: { "run-build": true } },
 		"sync",
-		{
-			name: "deploy",
-			with: { docs: true, preview: { project: "theholocron-preview", domain: "preview.theholocron.dev" } },
-		},
+		{ name: "deploy", with: { docs: true, preview: true } },
 	],
-	providers,
+	providers: {
+		...providers,
+		deployment: "cloudflare",
+		dns: "cloudflare",
+	},
 	agent: "claude",
 	skills: ["git-safety", "pr-workflow", "commit-standards", "security-review", "holocron-skill-config", "turborepo"],
 } satisfies HolocronConfig);

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -55,7 +55,10 @@ export default defineConfig({
 		{ name: "test", with: { "run-unit": true } },
 		{ name: "release", with: { "run-build": true } },
 		"sync",
-		{ name: "deploy", with: { docs: true, preview: { project: "theholocron-preview", domain: "preview.theholocron.dev" } } },
+		{
+			name: "deploy",
+			with: { docs: true, preview: { project: "theholocron-preview", domain: "preview.theholocron.dev" } },
+		},
 	],
 	providers,
 	agent: "claude",

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -55,7 +55,7 @@ export default defineConfig({
 		{ name: "test", with: { "run-unit": true } },
 		{ name: "release", with: { "run-build": true } },
 		"sync",
-		{ name: "deploy", with: { docs: true } },
+		{ name: "deploy", with: { docs: true, preview: { project: "theholocron-preview", domain: "preview.theholocron.dev" } } },
 	],
 	providers,
 	agent: "claude",


### PR DESCRIPTION
Adds deploy preview and cleanup to the deploy workflow, matching the setup already in `theholocron/clients` and `theholocron/holocron`.

**`deploy.yml`:**
- Add `pull_request` trigger with `types: [opened, synchronize, reopened, closed]` and matching `paths`
- Update `concurrency` to use a PR-scoped group and skip cancellation on `closed` events
- Expand `permissions` to include `deployments: write` and `pull-requests: write`
- Guard `deploy` job with `if: github.event_name != 'pull_request'`
- Add `preview` job (Cloudflare Pages branch deployment on PR open/update)
- Add `cleanup` job (deletes the CF Pages deployment on PR close/merge)

**`holocron.config.ts`:**
- Add `preview: { project: "theholocron-preview", domain: "preview.theholocron.dev" }` to the `deploy` workflow config so `holocron sync` regenerates this correctly in the future.