### PR TITLE
docs: 📚 add preset system spec and ADR 001

### DIFF
--- a/.notes/decisions/001-holocron-config-preset-system.md
+++ b/.notes/decisions/001-holocron-config-preset-system.md
@@ -1,0 +1,75 @@
+# ADR 001 — Holocron Config Preset System
+
+**Status:** Proposed  
+**Date:** 2026-08-28  
+**Repo:** theholocron/configs
+
+---
+
+## Context
+
+Every `theholocron/*` repository contains a `holocron.config.ts` that wires up the Holocron CLI: which workflows to sync, which providers to use, which branch protection checks to require. As the org has grown, these files have diverged in predictable ways:
+
+- Every library/docs repo repeats the same `org`, `domain`, `docs`, and Cloudflare provider config with minor variations.
+- Every browser app repo repeats the same Vercel provider, audit options, and test flags.
+- Required checks lists are long, manually maintained, and drift when workflow jobs are renamed.
+- The only shared abstraction is `node()`, which covers the lowest common denominator (source, CI, issues providers + base workflow list). Everything above that is copy-pasted.
+
+When the deploy preview + cleanup workflow was added across six repos simultaneously, each `holocron.config.ts` had to be updated independently with identical additions. That manual sweep exposed the gap.
+
+## Decision
+
+Introduce a layered preset system in `@theholocron/holocron-config` and a companion **conclusion job pattern** in `theholocron/.github`.
+
+### 1. Conclusion job pattern (in `.github`)
+
+Add a `conclusion` job to each reusable workflow (`lint.yml`, `test.yml`, `typecheck.yml`, `audit.yml`). The job runs `if: always()`, depends on every other job, and fails if any sibling failed or was cancelled. Consuming repos then require `"Lint / Conclusion"` instead of individual job names.
+
+This decouples branch protection from internal job structure — when a workflow gains or renames a job, no `requiredChecks` arrays need updating.
+
+### 2. Preset hierarchy (in `holocron-config`)
+
+```
+node()          — base: providers, repo defaults, core workflows
+  └─ nodeDocs() — adds: org, domain, docs, cloudflare, deploy+preview workflow
+nextjs()        — browser app: vercel, audit, test flags, storybook, common checks
+react()         — browser app: same minus vercel + user-flow
+monorepo(base)  — extension: wraps any preset, overrides for workspace repos
+```
+
+Each preset returns a `HolocronPreset` fragment (providers, repo defaults, workflows). Consuming repos spread the preset into `defineConfig()` and add only the fields that are unique to that repo: `description`, `homepage`, `topics`, `requiredChecks` extensions, package-specific codecov components, and test/chromatic specifics.
+
+### 3. Required checks strategy
+
+Presets include only **stable, cross-repo** checks:
+
+```
+"Lint / Conclusion"
+"Test / Conclusion"
+"Typecheck / Conclusion"
+"audit / Conclusion"
+"codecov/patch"
+"codecov/project"
+```
+
+Per-repo `requiredChecks` arrays extend the preset with repo-specific entries — primarily `codecov/patch/<package>` and `codecov/project/<package>` components unique to that repo's package structure.
+
+## Consequences
+
+**Positive**
+
+- A new org-wide CI change (e.g., adding a deploy preview workflow) requires editing the preset once, not every repo.
+- `requiredChecks` arrays shrink from 15–20 entries to 5–8 stable entries plus per-repo package components.
+- Branch protection is insulated from internal workflow job renames.
+- The preset hierarchy documents the org's repo taxonomy explicitly.
+
+**Negative**
+
+- Adding a new preset requires a release of `@theholocron/holocron-config` before consuming repos can adopt it — two-PR chains per change.
+- `codecov/patch` at the repo level does not guarantee individual component thresholds are met; per-component entries in each repo are still needed for component-level enforcement.
+- The `monorepo()` extension pattern (function-wrapping rather than standalone preset) is less discoverable than a named preset.
+
+**Neutral**
+
+- Existing `node()` usage is unchanged; adoption of the new presets is repo-by-repo.
+- Template repos are excluded from the node/docs presets since they have divergent testing setups.

--- a/.notes/preset-system.md
+++ b/.notes/preset-system.md
@@ -1,0 +1,257 @@
+---
+title: Holocron Config Preset System
+description: Layered configuration presets for theholocron repositories — what each preset includes, how to compose them, and what stays per-repo.
+---
+
+`@theholocron/holocron-config` ships a set of presets that encode the standard configuration for each class of `theholocron/*` repository. Each preset returns a fragment — `providers`, `repo`, `workflows` — that you spread into `defineConfig()` and extend with only the fields unique to your repo.
+
+## Why presets?
+
+Every repo in the org shares a large common baseline: the same source/CI/issues providers, the same branch protection defaults, the same core workflows. Without presets, every `holocron.config.ts` repeats that baseline verbatim. When the baseline changes (new workflow, new provider, new required check), every repo needs a manual sweep.
+
+Presets make the baseline explicit and single-sourced. A repo's config should read as a diff against the standard, not a full restatement of it.
+
+## Preset hierarchy
+
+```
+node()          — base: providers, repo defaults, core workflows
+  └─ nodeDocs() — adds: org, domain, docs pages, Cloudflare, deploy+preview
+nextjs()        — browser app: Vercel, audit, test, Storybook, common checks
+react()         — browser app: same minus Vercel + user-flow
+monorepo(base)  — extension: wraps any preset with monorepo-specific overrides
+```
+
+---
+
+## `node()`
+
+The existing base preset. Every Node.js repo in the org uses this directly or via a derived preset.
+
+**Returns:**
+
+```ts
+providers: {
+  source: "github",
+  ci: "github",
+  issues: ["github", { labels: { inProgress: "status:in-progress", inReview: "status:in-review" } }],
+}
+repo: {
+  protection: "strict",
+  properties: { lifecycle: "active", open_source: true, runtime_environment: "node", uses_external_packages: true },
+}
+workflows: [
+  "lint", "test", "typecheck", "codeql",
+  "review", "stale", "greetings", "dependencies", "bookkeeping",
+]
+```
+
+**Usage:**
+
+```ts
+import { node } from "@theholocron/holocron-config";
+
+const { repo, workflows, providers } = node();
+export default defineConfig({
+  description: "...",
+  repo: { name: "theholocron/my-repo", topics: ["typescript"], ...repo },
+  workflows: [...workflows, { name: "release", with: { "run-build": true } }],
+  providers,
+});
+```
+
+---
+
+## `nodeDocs()`
+
+Extends `node()` for repos that publish a documentation site and deploy previews via Cloudflare Pages.
+
+**Adds on top of `node()`:**
+
+| Field                  | Value                                                                                                                                    |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `org`                  | `"theholocron"`                                                                                                                          |
+| `domain`               | `"theholocron.dev"`                                                                                                                      |
+| `docs`                 | `{ build: "workflow", https: true }`                                                                                                     |
+| `providers.deployment` | `"cloudflare"`                                                                                                                           |
+| `providers.dns`        | `"cloudflare"`                                                                                                                           |
+| `workflows`            | `{ name: "deploy", with: { docs: true, preview: true } }`                                                                                |
+| `requiredChecks`       | `"Lint / Conclusion"`, `"Test / Conclusion"`, `"Typecheck / Conclusion"`, `"audit / Conclusion"`, `"codecov/patch"`, `"codecov/project"` |
+
+**Per-repo still provides:** `description`, `homepage`, `repo.name/topics/teams`, `requiredChecks` extensions (`codecov/patch/<package>` per package), extra providers (`vault`, `secrets`, `environments`), extra workflow options (`release`, `audit`, `test` choices).
+
+**Usage:**
+
+```ts
+import { nodeDocs } from "@theholocron/holocron-config";
+
+const { repo, workflows, providers, org, domain, docs } = nodeDocs();
+export default defineConfig({
+  description: "...",
+  homepage: "https://docs.theholocron.dev/my-lib/",
+  org,
+  domain,
+  docs,
+  repo: {
+    ...repo,
+    name: "theholocron/my-lib",
+    topics: ["typescript", "library"],
+    requiredChecks: [...repo.requiredChecks, "codecov/patch/my-package", "codecov/project/my-package"],
+  },
+  workflows: [...workflows, "audit", { name: "release", with: { "run-build": true } }],
+  providers: { ...providers, secrets: "github" },
+});
+```
+
+**Repos using this preset:** `configs`, `utils`, `themes`, `skills`, `docs`, `clients`, `holocron`
+
+---
+
+## `nextjs()`
+
+For single-package Next.js application repos.
+
+**Includes:**
+
+| Field                                    | Value                                                                                                           |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `org`                                    | `"theholocron"`                                                                                                 |
+| `domain`                                 | `"theholocron.dev"`                                                                                             |
+| `repo.properties.runtime_environment`    | `"browser"`                                                                                                     |
+| `repo.properties.uses_external_packages` | `false`                                                                                                         |
+| `providers.deployment`                   | `"vercel"`                                                                                                      |
+| `providers.secrets`                      | `"github"`                                                                                                      |
+| `workflows.audit`                        | `{ run-knip: true, run-performance: true, lighthouse-config: "lighthouse.config.cjs" }`                         |
+| `workflows.test`                         | `{ run-unit: false, run-storybook: true, run-interaction: true, run-user-flow: true }`                          |
+| `requiredChecks`                         | Conclusion jobs + `codecov/patch`, `codecov/project`, `Storybook Publish`, `UI Review`, `UI Tests`, `lhci/url/` |
+
+**Per-repo still provides:** `run-chromatic` configuration (projects and tokenName vary), `wait-on-url`, cypress check names, storybook deploy config.
+
+**Usage:**
+
+```ts
+import { nextjs } from "@theholocron/holocron-config";
+
+const { repo, workflows, providers, org, domain } = nextjs();
+export default defineConfig({
+  description: "...",
+  org,
+  domain,
+  repo: {
+    ...repo,
+    name: "theholocron/my-app",
+    topics: ["nextjs", "typescript"],
+  },
+  workflows: [
+    ...workflows,
+    { name: "test", with: { "run-chromatic": true, "wait-on-url": "http://localhost:3000" } },
+    "sync",
+    { name: "deploy", with: { docs: true, storybook: [{ name: "" }] } },
+  ],
+  providers,
+});
+```
+
+---
+
+## `react()`
+
+For single-package React/Vite application repos. Identical to `nextjs()` except:
+
+- No `deployment: "vercel"` (deploy target left per-repo)
+- No `run-user-flow` in the test preset (Cypress not assumed)
+- `lighthouse-config` optional
+
+**Usage** follows the same pattern as `nextjs()`.
+
+**Repos using this preset:** `react-template`
+
+---
+
+## `monorepo(base)`
+
+A function that wraps any base preset and applies monorepo-specific overrides. It is an extension, not a standalone preset — it always takes a base.
+
+**Overrides:**
+
+| Field                                    | Change                                                                      |
+| ---------------------------------------- | --------------------------------------------------------------------------- |
+| `repo.properties.uses_external_packages` | `true` (workspaces pull in many deps)                                       |
+| `workflows.test`                         | Adds `run-chromatic` in projects-array format                               |
+| `workflows.deploy`                       | Switches storybook from single `{ name: "" }` to `storybook-projects` array |
+
+**Per-repo still provides:** the actual `storybook-projects` array content, chromatic project definitions, workspace-specific required checks.
+
+**Usage:**
+
+```ts
+import { monorepo, nextjs } from "@theholocron/holocron-config";
+
+const { repo, workflows, providers, org, domain } = monorepo(nextjs());
+export default defineConfig({
+  org,
+  domain,
+  repo: { ...repo, name: "theholocron/my-monorepo" },
+  workflows: [
+    ...workflows,
+    {
+      name: "test",
+      with: {
+        "run-chromatic": {
+          projects: [{ tokenName: "default", workingDir: "apps/web" }],
+        },
+      },
+    },
+    {
+      name: "deploy",
+      with: {
+        docs: true,
+        "storybook-projects": [{ name: "web", workingDir: "apps/web" }],
+      },
+    },
+  ],
+  providers,
+});
+```
+
+**Repos using this extension:** `monorepo-nextjs-template`, `monorepo-react-template`
+
+---
+
+## Required checks strategy
+
+Presets include only stable, cross-repo required checks — the **Conclusion job** from each workflow plus top-level Codecov statuses:
+
+```
+"Lint / Conclusion"
+"Test / Conclusion"
+"Typecheck / Conclusion"
+"audit / Conclusion"
+"codecov/patch"
+"codecov/project"
+```
+
+Each repo extends `repo.requiredChecks` with its own package-level Codecov components:
+
+```ts
+requiredChecks: [
+  ...repo.requiredChecks,           // from preset
+  "codecov/patch/my-package-a",
+  "codecov/patch/my-package-b",
+  "codecov/project/my-package-a",
+  "codecov/project/my-package-b",
+],
+```
+
+The Conclusion job pattern (see [ADR 001](./decisions/001-holocron-config-preset-system.md)) means that when a workflow gains or renames a job, no `requiredChecks` array needs updating — only the workflow file itself changes.
+
+---
+
+## What never goes in a preset
+
+- **`description`** and **`homepage`** — unique to each repo
+- **`repo.name`** — must be explicit
+- **`repo.topics`** — unique to each repo's subject matter
+- **Package-level `codecov` checks** — unique to each repo's package structure
+- **`run-chromatic` project configuration** — varies by app structure
+- **Test-specific `with` options** (`wait-on-url`, specific build scripts) — varies by app
+- **Template repo configs** — templates have divergent testing setups and are excluded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ### Bug Fixes
 
-* **astro-config:** 🐛 bump @astrojs/react to ^5.0.0 — v4 uses @vitejs/plugin-react peered to vite@6, incompatible with Astro 7 / Vite 8 Rolldown ([#395](https://github.com/theholocron/configs/issues/395)) ([7697638](https://github.com/theholocron/configs/commit/7697638abd6d7299a5d522824a4fbee7f33d7ea8))
+- **astro-config:** 🐛 bump @astrojs/react to ^5.0.0 — v4 uses @vitejs/plugin-react peered to vite@6, incompatible with Astro 7 / Vite 8 Rolldown ([#395](https://github.com/theholocron/configs/issues/395)) ([7697638](https://github.com/theholocron/configs/commit/7697638abd6d7299a5d522824a4fbee7f33d7ea8))
 
 ## [7.25.4](https://github.com/theholocron/configs/compare/v7.25.3...v7.25.4) (2026-08-26)
 
 ### Bug Fixes
 
-* 🐛 disable no-nested-exports in packageJson() config ([#394](https://github.com/theholocron/configs/issues/394)) ([72a2121](https://github.com/theholocron/configs/commit/72a2121b0a718547814676f0aff77bd94ac0e7d7))
+- 🐛 disable no-nested-exports in packageJson() config ([#394](https://github.com/theholocron/configs/issues/394)) ([72a2121](https://github.com/theholocron/configs/commit/72a2121b0a718547814676f0aff77bd94ac0e7d7))
 
 ## [7.25.3](https://github.com/theholocron/configs/compare/v7.25.2...v7.25.3) (2026-08-26)
 


### PR DESCRIPTION
Adds the spec and architecture decision record for the upcoming `holocron-config` preset system before implementation begins.

Refs #398

**`.notes/preset-system.md`**
Full specification: preset hierarchy (`node`, `nodeDocs`, `nextjs`, `react`, `monorepo`), what each includes, how to compose them, what stays per-repo, and the required-checks strategy using the conclusion-job pattern.

**`.notes/decisions/001-holocron-config-preset-system.md`**
ADR: context (copy-paste drift across repos), the decision (preset hierarchy + conclusion jobs), and consequences.