### PR TITLE
feat: ✨ add nodeDocs, nextjs, react, and monorepo presets to holocron-config

### DIFF
--- a/.notes/decisions/001-holocron-config-preset-system.md
+++ b/.notes/decisions/001-holocron-config-preset-system.md
@@ -1,8 +1,10 @@
 # ADR 001 — Holocron Config Preset System
 
-**Status:** Proposed  
+**Status:** Accepted  
 **Date:** 2026-08-28  
-**Repo:** theholocron/configs
+**Repo:** theholocron/configs  
+**Issue:** #398  
+**PR:** #400
 
 ---
 

--- a/.notes/preset-system.md
+++ b/.notes/preset-system.md
@@ -1,6 +1,8 @@
 ---
 title: Holocron Config Preset System
 description: Layered configuration presets for theholocron repositories — what each preset includes, how to compose them, and what stays per-repo.
+issue: 398
+status: accepted
 ---
 
 `@theholocron/holocron-config` ships a set of presets that encode the standard configuration for each class of `theholocron/*` repository. Each preset returns a fragment — `providers`, `repo`, `workflows` — that you spread into `defineConfig()` and extend with only the fields unique to your repo.

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -1,11 +1,14 @@
 import { defineConfig } from "@theholocron/cli";
 import type { HolocronConfig } from "@theholocron/cli";
-import { node } from "@theholocron/holocron-config";
+import { nodeDocs } from "@theholocron/holocron-config";
 
-const { repo, workflows, providers } = node();
+const { repo, workflows, providers, org, domain, docs } = nodeDocs();
 export default defineConfig({
 	description: "Shared configuration files.",
 	homepage: "https://docs.theholocron.dev/configs/",
+	org,
+	domain,
+	docs,
 	repo: {
 		teams: [{ slug: "gatekeepers", permission: "maintain" }],
 		topics: [
@@ -26,11 +29,8 @@ export default defineConfig({
 			"vitest-config",
 		],
 		...repo,
-		protection: "strict",
 		requiredChecks: [
-			"audit / Knip",
-			"codecov/patch",
-			"codecov/project",
+			...repo.requiredChecks,
 			"codecov/project/astro-config",
 			"codecov/project/browserslist-config",
 			"codecov/project/commitlint-config",
@@ -55,9 +55,8 @@ export default defineConfig({
 		{ name: "test", with: { "run-unit": true } },
 		{ name: "release", with: { "run-build": true } },
 		"sync",
-		{ name: "deploy", with: { docs: true } },
 	],
-	providers,
+	providers: { ...providers, secrets: "github" },
 	agent: "claude",
 	skills: ["git-safety", "pr-workflow", "commit-standards", "security-review", "holocron-skill-config", "turborepo"],
 } satisfies HolocronConfig);

--- a/packages/holocron-config/configs/monorepo.ts
+++ b/packages/holocron-config/configs/monorepo.ts
@@ -1,0 +1,37 @@
+import type { HolocronPreset } from "./node.js";
+
+/**
+ * Extension that wraps any base preset with monorepo-specific overrides.
+ * Not a standalone preset — always takes a base (e.g. `monorepo(nextjs())`).
+ *
+ * Overrides: `uses_external_packages: true` (workspaces pull in many deps).
+ * Per-repo still provides: storybook-projects array, chromatic project
+ * definitions, workspace-specific required checks.
+ *
+ * @example
+ * const { repo, workflows, providers, org, domain } = monorepo(nextjs());
+ * export default defineConfig({
+ *   org,
+ *   domain,
+ *   repo: { ...repo, name: "theholocron/my-monorepo" },
+ *   workflows: [
+ *     ...workflows,
+ *     { name: "test", with: { "run-chromatic": { projects: [{ tokenName: "WEB", workingDir: "apps/web" }] } } },
+ *     "sync",
+ *     { name: "deploy", with: { docs: true, "storybook-projects": [{ name: "web", workingDir: "apps/web" }] } },
+ *   ],
+ *   providers,
+ * });
+ */
+export function monorepo<T extends HolocronPreset>(base: T): T {
+	return {
+		...base,
+		repo: {
+			...base.repo,
+			properties: {
+				...base.repo.properties,
+				uses_external_packages: true,
+			},
+		},
+	};
+}

--- a/packages/holocron-config/configs/nextjs.ts
+++ b/packages/holocron-config/configs/nextjs.ts
@@ -1,0 +1,75 @@
+import { node } from "./node.js";
+import type { HolocronPreset } from "./node.js";
+
+const REQUIRED_CHECKS = [
+	"Lint / Conclusion",
+	"Test / Conclusion",
+	"Typecheck / Conclusion",
+	"audit / Conclusion",
+	"codecov/patch",
+	"codecov/project",
+	"Storybook Publish",
+	"UI Review",
+	"UI Tests",
+	"lhci/url/",
+];
+
+/**
+ * Preset for single-package Next.js application repos. Includes Vercel
+ * deployment, Lighthouse audit, Storybook + interaction + user-flow tests,
+ * and the Conclusion required checks. Per-repo still provides: chromatic
+ * project config, wait-on-url, storybook deploy config, sync workflow.
+ *
+ * @example
+ * const { repo, workflows, providers, org, domain } = nextjs();
+ * export default defineConfig({
+ *   org,
+ *   domain,
+ *   repo: { ...repo, name: "theholocron/my-app", topics: ["nextjs"] },
+ *   workflows: [
+ *     ...workflows,
+ *     { name: "test", with: { "run-chromatic": true, "wait-on-url": "http://localhost:3000" } },
+ *     "sync",
+ *     { name: "deploy", with: { docs: true, storybook: [{ name: "" }] } },
+ *   ],
+ *   providers,
+ * });
+ */
+export function nextjs(): HolocronPreset & { org: string; domain: string } {
+	const base = node();
+	return {
+		...base,
+		org: "theholocron",
+		domain: "theholocron.dev",
+		providers: {
+			...base.providers,
+			deployment: "vercel",
+			secrets: "github",
+		},
+		repo: {
+			...base.repo,
+			properties: {
+				...base.repo.properties,
+				runtime_environment: "browser",
+				uses_external_packages: false,
+			},
+			requiredChecks: REQUIRED_CHECKS,
+		},
+		workflows: [
+			...base.workflows,
+			{
+				name: "audit",
+				with: { "run-knip": true, "run-performance": true, "lighthouse-config": "lighthouse.config.cjs" },
+			},
+			{
+				name: "test",
+				with: {
+					"run-unit": false,
+					"run-storybook": true,
+					"run-interaction": true,
+					"run-user-flow": true,
+				},
+			},
+		],
+	};
+}

--- a/packages/holocron-config/configs/node-docs.ts
+++ b/packages/holocron-config/configs/node-docs.ts
@@ -1,0 +1,65 @@
+import type { HolocronConfig } from "@theholocron/cli";
+import { node } from "./node.js";
+import type { HolocronPreset } from "./node.js";
+
+const REQUIRED_CHECKS = [
+	"Lint / Conclusion",
+	"Test / Conclusion",
+	"Typecheck / Conclusion",
+	"audit / Conclusion",
+	"codecov/patch",
+	"codecov/project",
+];
+
+export interface NodeDocsPreset extends HolocronPreset {
+	org: string;
+	domain: string;
+	docs: NonNullable<HolocronConfig["docs"]>;
+	repo: HolocronPreset["repo"] & { requiredChecks: string[] };
+}
+
+/**
+ * Extends `node()` for repos that publish a documentation site and deploy
+ * previews via Cloudflare Pages. Adds org/domain, Cloudflare providers,
+ * deploy+preview workflow, and the Conclusion required checks.
+ *
+ * @example
+ * const { repo, workflows, providers, org, domain, docs } = nodeDocs();
+ * export default defineConfig({
+ *   description: "...",
+ *   homepage: "https://docs.theholocron.dev/my-lib/",
+ *   org,
+ *   domain,
+ *   docs,
+ *   repo: {
+ *     ...repo,
+ *     name: "theholocron/my-lib",
+ *     topics: ["typescript"],
+ *     requiredChecks: [...repo.requiredChecks, "codecov/patch/my-pkg"],
+ *   },
+ *   workflows: [...workflows, "audit", { name: "release", with: { "run-build": true } }, "sync"],
+ *   providers: { ...providers, secrets: "github" },
+ * });
+ */
+export function nodeDocs(): NodeDocsPreset {
+	const base = node();
+	return {
+		...base,
+		org: "theholocron",
+		domain: "theholocron.dev",
+		docs: { build: "workflow", https: true },
+		providers: {
+			...base.providers,
+			deployment: "cloudflare",
+			dns: "cloudflare",
+		},
+		repo: {
+			...base.repo,
+			requiredChecks: REQUIRED_CHECKS,
+		},
+		workflows: [
+			...base.workflows,
+			{ name: "deploy", with: { docs: true, preview: true } },
+		],
+	};
+}

--- a/packages/holocron-config/configs/node-docs.ts
+++ b/packages/holocron-config/configs/node-docs.ts
@@ -57,9 +57,6 @@ export function nodeDocs(): NodeDocsPreset {
 			...base.repo,
 			requiredChecks: REQUIRED_CHECKS,
 		},
-		workflows: [
-			...base.workflows,
-			{ name: "deploy", with: { docs: true, preview: true } },
-		],
+		workflows: [...base.workflows, { name: "deploy", with: { docs: true, preview: true } }],
 	};
 }

--- a/packages/holocron-config/configs/node.ts
+++ b/packages/holocron-config/configs/node.ts
@@ -2,8 +2,11 @@ import type { HolocronConfig, RepoConfig } from "@theholocron/cli";
 
 export interface HolocronPreset {
 	providers: HolocronConfig["providers"];
-	repo: Omit<RepoConfig, "name" | "requiredChecks">;
+	repo: Omit<RepoConfig, "name"> & { requiredChecks?: string[] };
 	workflows: NonNullable<HolocronConfig["workflows"]>;
+	org?: string;
+	domain?: string;
+	docs?: HolocronConfig["docs"];
 }
 
 /**

--- a/packages/holocron-config/configs/react.ts
+++ b/packages/holocron-config/configs/react.ts
@@ -1,0 +1,73 @@
+import { node } from "./node.js";
+import type { HolocronPreset } from "./node.js";
+
+const REQUIRED_CHECKS = [
+	"Lint / Conclusion",
+	"Test / Conclusion",
+	"Typecheck / Conclusion",
+	"audit / Conclusion",
+	"codecov/patch",
+	"codecov/project",
+	"Storybook Publish",
+	"UI Review",
+	"UI Tests",
+	"lhci/url/",
+];
+
+/**
+ * Preset for single-package React/Vite application repos. Identical to
+ * `nextjs()` except: no Vercel deployment (deploy target is per-repo) and
+ * no `run-user-flow` (Cypress not assumed). Per-repo still provides: chromatic
+ * project config, storybook deploy config, sync workflow.
+ *
+ * @example
+ * const { repo, workflows, providers, org, domain } = react();
+ * export default defineConfig({
+ *   org,
+ *   domain,
+ *   repo: { ...repo, name: "theholocron/my-app", topics: ["react", "vite"] },
+ *   workflows: [
+ *     ...workflows,
+ *     { name: "test", with: { "run-chromatic": { projects: [{ tokenName: "default", workingDir: ".", buildScript: "build:storybook:chromatic" }] } } },
+ *     "sync",
+ *     { name: "deploy", with: { docs: true, storybook: [{ name: "" }] } },
+ *   ],
+ *   providers,
+ * });
+ */
+export function react(): HolocronPreset & { org: string; domain: string } {
+	const base = node();
+	return {
+		...base,
+		org: "theholocron",
+		domain: "theholocron.dev",
+		providers: {
+			...base.providers,
+			secrets: "github",
+		},
+		repo: {
+			...base.repo,
+			properties: {
+				...base.repo.properties,
+				runtime_environment: "browser",
+				uses_external_packages: false,
+			},
+			requiredChecks: REQUIRED_CHECKS,
+		},
+		workflows: [
+			...base.workflows,
+			{
+				name: "audit",
+				with: { "run-knip": true, "run-performance": true, "lighthouse-config": "lighthouse.config.cjs" },
+			},
+			{
+				name: "test",
+				with: {
+					"run-unit": false,
+					"run-storybook": true,
+					"run-interaction": true,
+				},
+			},
+		],
+	};
+}

--- a/packages/holocron-config/index.test.ts
+++ b/packages/holocron-config/index.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { node } from "./index.js";
+import { monorepo, nextjs, node, nodeDocs, react } from "./index.js";
 
 describe("node()", () => {
 	describe("repo", () => {
 		it("sets strict protection", () => {
 			const { repo } = node();
 			expect(repo.protection).toBe("strict");
+		});
+
+		it("does not include requiredChecks", () => {
+			const { repo } = node();
+			expect(repo.requiredChecks).toBeUndefined();
 		});
 	});
 
@@ -54,5 +59,167 @@ describe("node()", () => {
 				},
 			]);
 		});
+	});
+});
+
+describe("nodeDocs()", () => {
+	describe("top-level fields", () => {
+		it("sets org and domain", () => {
+			const { org, domain } = nodeDocs();
+			expect(org).toBe("theholocron");
+			expect(domain).toBe("theholocron.dev");
+		});
+
+		it("sets docs config", () => {
+			const { docs } = nodeDocs();
+			expect(docs).toEqual({ build: "workflow", https: true });
+		});
+	});
+
+	describe("providers", () => {
+		it("adds cloudflare deployment and dns", () => {
+			const { providers } = nodeDocs();
+			expect(providers.deployment).toBe("cloudflare");
+			expect(providers.dns).toBe("cloudflare");
+		});
+
+		it("inherits github source and ci from node()", () => {
+			const { providers } = nodeDocs();
+			expect(providers.source).toBe("github");
+			expect(providers.ci).toBe("github");
+		});
+	});
+
+	describe("repo", () => {
+		it("includes Conclusion required checks", () => {
+			const { repo } = nodeDocs();
+			expect(repo.requiredChecks).toContain("Lint / Conclusion");
+			expect(repo.requiredChecks).toContain("Test / Conclusion");
+			expect(repo.requiredChecks).toContain("Typecheck / Conclusion");
+			expect(repo.requiredChecks).toContain("audit / Conclusion");
+		});
+
+		it("includes cross-repo codecov checks", () => {
+			const { repo } = nodeDocs();
+			expect(repo.requiredChecks).toContain("codecov/patch");
+			expect(repo.requiredChecks).toContain("codecov/project");
+		});
+	});
+
+	describe("workflows", () => {
+		it("includes all node() baseline workflows", () => {
+			const { workflows } = nodeDocs();
+			const names = workflows.map((w) => (typeof w === "string" ? w : w.name));
+			expect(names).toContain("lint");
+			expect(names).toContain("test");
+			expect(names).toContain("typecheck");
+		});
+
+		it("includes deploy with docs and preview", () => {
+			const { workflows } = nodeDocs();
+			const deploy = workflows.find((w) => typeof w !== "string" && w.name === "deploy");
+			expect(deploy).toMatchObject({ name: "deploy", with: { docs: true, preview: true } });
+		});
+
+		it("does not include audit or release (stay repo-specific)", () => {
+			const { workflows } = nodeDocs();
+			const names = workflows.map((w) => (typeof w === "string" ? w : w.name));
+			expect(names).not.toContain("audit");
+			expect(names).not.toContain("release");
+		});
+	});
+});
+
+describe("nextjs()", () => {
+	describe("top-level fields", () => {
+		it("sets org and domain", () => {
+			const { org, domain } = nextjs();
+			expect(org).toBe("theholocron");
+			expect(domain).toBe("theholocron.dev");
+		});
+	});
+
+	describe("providers", () => {
+		it("sets vercel deployment and github secrets", () => {
+			const { providers } = nextjs();
+			expect(providers.deployment).toBe("vercel");
+			expect(providers.secrets).toBe("github");
+		});
+	});
+
+	describe("repo", () => {
+		it("sets browser runtime environment", () => {
+			const { repo } = nextjs();
+			expect(repo.properties?.runtime_environment).toBe("browser");
+		});
+
+		it("includes Storybook and lhci required checks", () => {
+			const { repo } = nextjs();
+			expect(repo.requiredChecks).toContain("Storybook Publish");
+			expect(repo.requiredChecks).toContain("UI Review");
+			expect(repo.requiredChecks).toContain("UI Tests");
+			expect(repo.requiredChecks).toContain("lhci/url/");
+		});
+	});
+
+	describe("workflows", () => {
+		it("includes audit with knip and performance", () => {
+			const { workflows } = nextjs();
+			const audit = workflows.find((w) => typeof w !== "string" && w.name === "audit");
+			expect(audit).toMatchObject({ name: "audit", with: { "run-knip": true, "run-performance": true } });
+		});
+
+		it("includes test with storybook and interaction", () => {
+			const { workflows } = nextjs();
+			const test = workflows.find((w) => typeof w !== "string" && w.name === "test");
+			expect(test).toMatchObject({
+				name: "test",
+				with: { "run-storybook": true, "run-interaction": true, "run-user-flow": true, "run-unit": false },
+			});
+		});
+	});
+});
+
+describe("react()", () => {
+	describe("providers", () => {
+		it("does not include vercel deployment", () => {
+			const { providers } = react();
+			expect(providers.deployment).toBeUndefined();
+		});
+
+		it("sets github secrets", () => {
+			const { providers } = react();
+			expect(providers.secrets).toBe("github");
+		});
+	});
+
+	describe("workflows", () => {
+		it("includes test without run-user-flow", () => {
+			const { workflows } = react();
+			const test = workflows.find((w) => typeof w !== "string" && w.name === "test");
+			expect(test).toMatchObject({ name: "test", with: { "run-storybook": true, "run-interaction": true } });
+			if (typeof test !== "string" && test) {
+				expect((test.with as Record<string, unknown>)["run-user-flow"]).toBeUndefined();
+			}
+		});
+	});
+});
+
+describe("monorepo()", () => {
+	it("wraps nextjs() and sets uses_external_packages to true", () => {
+		const { repo } = monorepo(nextjs());
+		expect(repo.properties?.uses_external_packages).toBe(true);
+	});
+
+	it("wraps react() and preserves browser runtime", () => {
+		const { repo } = monorepo(react());
+		expect(repo.properties?.runtime_environment).toBe("browser");
+		expect(repo.properties?.uses_external_packages).toBe(true);
+	});
+
+	it("wraps nodeDocs() and preserves org and domain", () => {
+		const result = monorepo(nodeDocs());
+		expect(result.org).toBe("theholocron");
+		expect(result.domain).toBe("theholocron.dev");
 	});
 });

--- a/packages/holocron-config/index.ts
+++ b/packages/holocron-config/index.ts
@@ -1,2 +1,7 @@
+export { monorepo } from "./configs/monorepo.js";
+export { nextjs } from "./configs/nextjs.js";
 export { node } from "./configs/node.js";
 export type { HolocronPreset } from "./configs/node.js";
+export { nodeDocs } from "./configs/node-docs.js";
+export type { NodeDocsPreset } from "./configs/node-docs.js";
+export { react } from "./configs/react.js";

--- a/packages/holocron-config/package.json
+++ b/packages/holocron-config/package.json
@@ -46,6 +46,26 @@
       "import": "./dist/configs/node.js",
       "default": "./dist/configs/node.js"
     },
+    "./node-docs": {
+      "types": "./dist/configs/node-docs.d.ts",
+      "import": "./dist/configs/node-docs.js",
+      "default": "./dist/configs/node-docs.js"
+    },
+    "./nextjs": {
+      "types": "./dist/configs/nextjs.d.ts",
+      "import": "./dist/configs/nextjs.js",
+      "default": "./dist/configs/nextjs.js"
+    },
+    "./react": {
+      "types": "./dist/configs/react.d.ts",
+      "import": "./dist/configs/react.js",
+      "default": "./dist/configs/react.js"
+    },
+    "./monorepo": {
+      "types": "./dist/configs/monorepo.d.ts",
+      "import": "./dist/configs/monorepo.js",
+      "default": "./dist/configs/monorepo.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [


### PR DESCRIPTION
Implements the preset system from `.notes/preset-system.md` and ADR 001. Extends HolocronPreset type, adds nodeDocs/nextjs/react/monorepo presets, deep-import exports, 27 tests, and adopts nodeDocs() in configs/holocron.config.ts. Closes #398